### PR TITLE
Add vscode default dark material theme

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -77,6 +77,7 @@
 |**[Tokyo Night Storm](tokyo_night_storm.yaml)**:|<img src='previews/tokyo_night_storm.yaml.svg' width='300'>|
 |**[Tomorrow Night](tomorrow_night.yaml)**:|<img src='previews/tomorrow_night.yaml.svg' width='300'>|
 |**[Tomorrow Night Bright](tomorrow_night_bright.yaml)**:|<img src='previews/tomorrow_night_bright.yaml.svg' width='300'>|
+|**[Vscode Default Dark Material](vscode_default_dark_material.yml)**:|<img src='previews/vscode_default_dark_material.yml.svg' width='300'>|
 |**[Vuesion](vuesion.yaml)**:|<img src='previews/vuesion.yaml.svg' width='300'>|
 |**[Wombat](wombat.yaml)**:|<img src='previews/wombat.yaml.svg' width='300'>|
 |**[Xterm](xterm.yaml)**:|<img src='previews/xterm.yaml.svg' width='300'>|

--- a/standard/previews/vscode_default_dark_material.yml.svg
+++ b/standard/previews/vscode_default_dark_material.yml.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145">
+<rect width="300" height="145" class="Dynamic" fill="#1a1a1a" rx="5" />
+
+<!-- first command -->
+<text x="15" y="15" fill="#eeffff" font-size="0.6em" font-family="monospace" class="Dynamic">ls</text>
+<text x="15" y="30" fill="#82aaff" font-size="0.6em" font-family="monospace" class="Dynamic">
+dir
+</text>
+<text x="65" y="30" fill="#ff5370" font-size="0.6em" font-family="monospace" class="Dynamic">
+executable
+</text>
+<text x="175" y="30" fill="#eeffff" font-size="0.6em" font-family="monospace" class="Dynamic">
+file
+</text>
+<line x1="0" y1="40" x2="300" y2="40" style="stroke-width:0.2"  class="Dynamic" stroke="#eeffff"/>
+
+<!-- second command -->
+<text x="15" y="55" fill="#eeffff" font-size="0.6em" font-family="monospace" class="Dynamic">bash ~/colors.sh</text>
+<text x="15" y="70" fill="#eeffff" font-size="0.6em" font-family="monospace" class="Dynamic">
+normal:
+</text>
+<text x="55" y="70" fill="#000000" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="70" fill="#ff5370" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="70" fill="#c3e88d" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="70" fill="#ffcb6b" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="70" fill="#82aaff" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="70" fill="#c792ea" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="70" fill="#89ddff" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="70" fill="#ffffff" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<text x="15" y="85" fill="#eeffff" font-size="0.6em" font-family="monospace" class='Dynamic'>
+bright:
+</text>
+<text x="55" y="85" fill="#4a4a4a" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="85" fill="#ff5370" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="85" fill="#c3e88d" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="85" fill="#ffcb6b" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="85" fill="#82aaff" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="85" fill="#c792ea" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="85" fill="#89ddff" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="85" fill="#ffffff" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<line x1="0" y1="95" x2="300" y2="95" style="stroke-width:0.2" class="Dynamic" stroke="#eeffff" />
+
+<!-- prompt -->
+<text x="15" y="110" fill="#c792ea" font-size="0.6em" font-family="monospace" class="Dynamic">
+~/project
+</text>
+<text x="65" y="110" fill="#c3e88d" font-size="0.6em" font-family="monospace" class="Dynamic">
+git(
+    </text>
+    <text x="85" y="110" fill="#ffcb6b" font-size="0.6em" font-family="monospace" class="Dynamic">
+      main
+    </text>
+    <text x="113" y="110" fill="#c3e88d" font-size="0.6em" font-family="monospace" class="Dynamic">
+      )
+</text>
+<!-- cursor -->
+<line x1="15" y1="120" x2="15" y2="130" style="stroke-width:2" class="Dynamic" stroke="#80cbc4" />
+</svg>

--- a/standard/vscode_default_dark_material.yml
+++ b/standard/vscode_default_dark_material.yml
@@ -1,0 +1,23 @@
+accent: '#80cbc4'
+background: '#1a1a1a'
+foreground: '#eeffff'
+details: darker
+terminal_colors:
+  bright:
+    black: '#4a4a4a'
+    blue: '#82aaff'
+    cyan: '#89ddff'
+    green: '#c3e88d'
+    magenta: '#c792ea'
+    red: '#ff5370'
+    white: '#ffffff'
+    yellow: '#ffcb6b'
+  normal:
+    black: '#000000'
+    blue: '#82aaff'
+    cyan: '#89ddff'
+    green: '#c3e88d'
+    magenta: '#c792ea'
+    red: '#ff5370'
+    white: '#ffffff'
+    yellow: '#ffcb6b'


### PR DESCRIPTION
This theme is based on the [Default Material Dark Theme](https://github.com/yuchiu/Default-Material-Dark-Theme) for visual studio code (which is highly underrated by the way)

## Discord username (optional)
satoqz#7996

## Name of theme
vscode default dark material

## How Has This Been Tested?

Have you run the python script? yes
