### PR TITLE
Correct base snazzy theme and adds variants

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -68,6 +68,9 @@
 |**[Seashells](seashells.yaml)**:|<img src='previews/seashells.yaml.svg' width='300'>|
 |**[Simply Dark](simply_dark.yaml)**:|<img src='previews/simply_dark.yaml.svg' width='300'>|
 |**[Snazzy](snazzy.yaml)**:|<img src='previews/snazzy.yaml.svg' width='300'>|
+|**[Snazzy Blue](snazzy_blue.yaml)**:|<img src='previews/snazzy_blue.yaml.svg' width='300'>|
+|**[Snazzy Green](snazzy_green.yaml)**:|<img src='previews/snazzy_green.yaml.svg' width='300'>|
+|**[Snazzy Red](snazzy_red.yaml)**:|<img src='previews/snazzy_red.yaml.svg' width='300'>|
 |**[Solarized Dark](solarized_dark.yaml)**:|<img src='previews/solarized_dark.yaml.svg' width='300'>|
 |**[Solarized Light](solarized_light.yaml)**:|<img src='previews/solarized_light.yaml.svg' width='300'>|
 |**[Taerminal](taerminal.yaml)**:|<img src='previews/taerminal.yaml.svg' width='300'>|

--- a/standard/previews/snazzy.yaml.svg
+++ b/standard/previews/snazzy.yaml.svg
@@ -67,7 +67,7 @@ magenta
 <text x="235" y="85" fill="#9aedfe" font-size="0.6em" font-family="monospace" class="Dynamic">
 cyan
 </text>
-<text x="260" y="85" fill="#f1f1f0" font-size="0.6em" font-family="monospace" class="Dynamic">
+<text x="260" y="85" fill="#eff0eb" font-size="0.6em" font-family="monospace" class="Dynamic">
 white
 </text>
 <line x1="0" y1="95" x2="300" y2="95" style="stroke-width:0.2" class="Dynamic" stroke="#eff0eb" />
@@ -86,5 +86,5 @@ git(
       )
 </text>
 <!-- cursor -->
-<line x1="15" y1="120" x2="15" y2="130" style="stroke-width:2" class="Dynamic" stroke="#57c7ff" />
+<line x1="15" y1="120" x2="15" y2="130" style="stroke-width:2" class="Dynamic" stroke="#ff6ac1" />
 </svg>

--- a/standard/previews/snazzy_blue.yaml.svg
+++ b/standard/previews/snazzy_blue.yaml.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145">
+<rect width="300" height="145" class="Dynamic" fill="#282a36" rx="5" />
+
+<!-- first command -->
+<text x="15" y="15" fill="#eff0eb" font-size="0.6em" font-family="monospace" class="Dynamic">ls</text>
+<text x="15" y="30" fill="#57c7ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+dir
+</text>
+<text x="65" y="30" fill="#ff5c57" font-size="0.6em" font-family="monospace" class="Dynamic">
+executable
+</text>
+<text x="175" y="30" fill="#eff0eb" font-size="0.6em" font-family="monospace" class="Dynamic">
+file
+</text>
+<line x1="0" y1="40" x2="300" y2="40" style="stroke-width:0.2"  class="Dynamic" stroke="#eff0eb"/>
+
+<!-- second command -->
+<text x="15" y="55" fill="#eff0eb" font-size="0.6em" font-family="monospace" class="Dynamic">bash ~/colors.sh</text>
+<text x="15" y="70" fill="#eff0eb" font-size="0.6em" font-family="monospace" class="Dynamic">
+normal:
+</text>
+<text x="55" y="70" fill="#282a36" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="70" fill="#ff5c57" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="70" fill="#5af78e" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="70" fill="#f3f99d" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="70" fill="#57c7ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="70" fill="#ff6ac1" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="70" fill="#9aedfe" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="70" fill="#f1f1f0" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<text x="15" y="85" fill="#eff0eb" font-size="0.6em" font-family="monospace" class='Dynamic'>
+bright:
+</text>
+<text x="55" y="85" fill="#686868" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="85" fill="#ff5c57" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="85" fill="#5af78e" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="85" fill="#f3f99d" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="85" fill="#57c7ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="85" fill="#ff6ac1" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="85" fill="#9aedfe" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="85" fill="#f1f1f0" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<line x1="0" y1="95" x2="300" y2="95" style="stroke-width:0.2" class="Dynamic" stroke="#eff0eb" />
+
+<!-- prompt -->
+<text x="15" y="110" fill="#ff6ac1" font-size="0.6em" font-family="monospace" class="Dynamic">
+~/project
+</text>
+<text x="65" y="110" fill="#5af78e" font-size="0.6em" font-family="monospace" class="Dynamic">
+git(
+    </text>
+    <text x="85" y="110" fill="#f3f99d" font-size="0.6em" font-family="monospace" class="Dynamic">
+      main
+    </text>
+    <text x="113" y="110" fill="#5af78e" font-size="0.6em" font-family="monospace" class="Dynamic">
+      )
+</text>
+<!-- cursor -->
+<line x1="15" y1="120" x2="15" y2="130" style="stroke-width:2" class="Dynamic" stroke="#57c7ff" />
+</svg>

--- a/standard/previews/snazzy_green.yaml.svg
+++ b/standard/previews/snazzy_green.yaml.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145">
+<rect width="300" height="145" class="Dynamic" fill="#282a36" rx="5" />
+
+<!-- first command -->
+<text x="15" y="15" fill="#eff0eb" font-size="0.6em" font-family="monospace" class="Dynamic">ls</text>
+<text x="15" y="30" fill="#57c7ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+dir
+</text>
+<text x="65" y="30" fill="#ff5c57" font-size="0.6em" font-family="monospace" class="Dynamic">
+executable
+</text>
+<text x="175" y="30" fill="#eff0eb" font-size="0.6em" font-family="monospace" class="Dynamic">
+file
+</text>
+<line x1="0" y1="40" x2="300" y2="40" style="stroke-width:0.2"  class="Dynamic" stroke="#eff0eb"/>
+
+<!-- second command -->
+<text x="15" y="55" fill="#eff0eb" font-size="0.6em" font-family="monospace" class="Dynamic">bash ~/colors.sh</text>
+<text x="15" y="70" fill="#eff0eb" font-size="0.6em" font-family="monospace" class="Dynamic">
+normal:
+</text>
+<text x="55" y="70" fill="#282a36" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="70" fill="#ff5c57" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="70" fill="#5af78e" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="70" fill="#f3f99d" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="70" fill="#57c7ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="70" fill="#ff6ac1" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="70" fill="#9aedfe" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="70" fill="#f1f1f0" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<text x="15" y="85" fill="#eff0eb" font-size="0.6em" font-family="monospace" class='Dynamic'>
+bright:
+</text>
+<text x="55" y="85" fill="#686868" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="85" fill="#ff5c57" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="85" fill="#5af78e" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="85" fill="#f3f99d" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="85" fill="#57c7ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="85" fill="#ff6ac1" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="85" fill="#9aedfe" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="85" fill="#f1f1f0" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<line x1="0" y1="95" x2="300" y2="95" style="stroke-width:0.2" class="Dynamic" stroke="#eff0eb" />
+
+<!-- prompt -->
+<text x="15" y="110" fill="#ff6ac1" font-size="0.6em" font-family="monospace" class="Dynamic">
+~/project
+</text>
+<text x="65" y="110" fill="#5af78e" font-size="0.6em" font-family="monospace" class="Dynamic">
+git(
+    </text>
+    <text x="85" y="110" fill="#f3f99d" font-size="0.6em" font-family="monospace" class="Dynamic">
+      main
+    </text>
+    <text x="113" y="110" fill="#5af78e" font-size="0.6em" font-family="monospace" class="Dynamic">
+      )
+</text>
+<!-- cursor -->
+<line x1="15" y1="120" x2="15" y2="130" style="stroke-width:2" class="Dynamic" stroke="#5af78e" />
+</svg>

--- a/standard/previews/snazzy_red.yaml.svg
+++ b/standard/previews/snazzy_red.yaml.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145">
+<rect width="300" height="145" class="Dynamic" fill="#282a36" rx="5" />
+
+<!-- first command -->
+<text x="15" y="15" fill="#eff0eb" font-size="0.6em" font-family="monospace" class="Dynamic">ls</text>
+<text x="15" y="30" fill="#57c7ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+dir
+</text>
+<text x="65" y="30" fill="#ff5c57" font-size="0.6em" font-family="monospace" class="Dynamic">
+executable
+</text>
+<text x="175" y="30" fill="#eff0eb" font-size="0.6em" font-family="monospace" class="Dynamic">
+file
+</text>
+<line x1="0" y1="40" x2="300" y2="40" style="stroke-width:0.2"  class="Dynamic" stroke="#eff0eb"/>
+
+<!-- second command -->
+<text x="15" y="55" fill="#eff0eb" font-size="0.6em" font-family="monospace" class="Dynamic">bash ~/colors.sh</text>
+<text x="15" y="70" fill="#eff0eb" font-size="0.6em" font-family="monospace" class="Dynamic">
+normal:
+</text>
+<text x="55" y="70" fill="#282a36" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="70" fill="#ff5c57" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="70" fill="#5af78e" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="70" fill="#f3f99d" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="70" fill="#57c7ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="70" fill="#ff6ac1" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="70" fill="#9aedfe" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="70" fill="#f1f1f0" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<text x="15" y="85" fill="#eff0eb" font-size="0.6em" font-family="monospace" class='Dynamic'>
+bright:
+</text>
+<text x="55" y="85" fill="#686868" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="85" fill="#ff5c57" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="85" fill="#5af78e" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="85" fill="#f3f99d" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="85" fill="#57c7ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="85" fill="#ff6ac1" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="85" fill="#9aedfe" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="85" fill="#f1f1f0" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<line x1="0" y1="95" x2="300" y2="95" style="stroke-width:0.2" class="Dynamic" stroke="#eff0eb" />
+
+<!-- prompt -->
+<text x="15" y="110" fill="#ff6ac1" font-size="0.6em" font-family="monospace" class="Dynamic">
+~/project
+</text>
+<text x="65" y="110" fill="#5af78e" font-size="0.6em" font-family="monospace" class="Dynamic">
+git(
+    </text>
+    <text x="85" y="110" fill="#f3f99d" font-size="0.6em" font-family="monospace" class="Dynamic">
+      main
+    </text>
+    <text x="113" y="110" fill="#5af78e" font-size="0.6em" font-family="monospace" class="Dynamic">
+      )
+</text>
+<!-- cursor -->
+<line x1="15" y1="120" x2="15" y2="130" style="stroke-width:2" class="Dynamic" stroke="#ff5c57" />
+</svg>

--- a/standard/snazzy.yaml
+++ b/standard/snazzy.yaml
@@ -1,24 +1,23 @@
-
-accent: '#57c7ff'
-background: '#282a36'
 details: darker
-foreground: '#eff0eb'
+accent: "#ff6ac1"
+background: "#282a36"
+foreground: "#eff0eb"
 terminal_colors:
   bright:
-    black: '#686868'
-    blue: '#57c7ff'
-    cyan: '#9aedfe'
-    green: '#5af78e'
-    magenta: '#ff6ac1'
-    red: '#ff5c57'
-    white: '#f1f1f0'
-    yellow: '#f3f99d'
+    black: "#686868"
+    blue: "#57c7ff"
+    cyan: "#9aedfe"
+    green: "#5af78e"
+    magenta: "#ff6ac1"
+    red: "#ff5c57"
+    white: "#eff0eb"
+    yellow: "#f3f99d"
   normal:
-    black: '#282a36'
-    blue: '#57c7ff'
-    cyan: '#9aedfe'
-    green: '#5af78e'
-    magenta: '#ff6ac1'
-    red: '#ff5c57'
-    white: '#f1f1f0'
-    yellow: '#f3f99d'
+    black: "#282a36"
+    blue: "#57c7ff"
+    cyan: "#9aedfe"
+    green: "#5af78e"
+    magenta: "#ff6ac1"
+    red: "#ff5c57"
+    white: "#f1f1f0"
+    yellow: "#f3f99d"

--- a/standard/snazzy_blue.yaml
+++ b/standard/snazzy_blue.yaml
@@ -1,0 +1,23 @@
+details: darker
+accent: "#57c7ff"
+background: "#282a36"
+foreground: "#eff0eb"
+terminal_colors:
+  bright:
+    black: "#686868"
+    blue: "#57c7ff"
+    cyan: "#9aedfe"
+    green: "#5af78e"
+    magenta: "#ff6ac1"
+    red: "#ff5c57"
+    white: "#f1f1f0"
+    yellow: "#f3f99d"
+  normal:
+    black: "#282a36"
+    blue: "#57c7ff"
+    cyan: "#9aedfe"
+    green: "#5af78e"
+    magenta: "#ff6ac1"
+    red: "#ff5c57"
+    white: "#f1f1f0"
+    yellow: "#f3f99d"

--- a/standard/snazzy_green.yaml
+++ b/standard/snazzy_green.yaml
@@ -1,0 +1,23 @@
+details: darker
+accent: "#5af78e"
+background: "#282a36"
+foreground: "#eff0eb"
+terminal_colors:
+  bright:
+    black: "#686868"
+    blue: "#57c7ff"
+    cyan: "#9aedfe"
+    green: "#5af78e"
+    magenta: "#ff6ac1"
+    red: "#ff5c57"
+    white: "#f1f1f0"
+    yellow: "#f3f99d"
+  normal:
+    black: "#282a36"
+    blue: "#57c7ff"
+    cyan: "#9aedfe"
+    green: "#5af78e"
+    magenta: "#ff6ac1"
+    red: "#ff5c57"
+    white: "#f1f1f0"
+    yellow: "#f3f99d"

--- a/standard/snazzy_red.yaml
+++ b/standard/snazzy_red.yaml
@@ -1,0 +1,23 @@
+details: darker
+accent: "#ff5c57"
+background: "#282a36"
+foreground: "#eff0eb"
+terminal_colors:
+  bright:
+    black: "#686868"
+    blue: "#57c7ff"
+    cyan: "#9aedfe"
+    green: "#5af78e"
+    magenta: "#ff6ac1"
+    red: "#ff5c57"
+    white: "#f1f1f0"
+    yellow: "#f3f99d"
+  normal:
+    black: "#282a36"
+    blue: "#57c7ff"
+    cyan: "#9aedfe"
+    green: "#5af78e"
+    magenta: "#ff6ac1"
+    red: "#ff5c57"
+    white: "#f1f1f0"
+    yellow: "#f3f99d"


### PR DESCRIPTION
# Pull Request Template

This pull request corrects the snazzy theme accent color based on [hyper-snazzy](https://github.com/sindresorhus/hyper-snazzy), and adds variants.

_The `snazzy_blue.yml` was `snazzy.yml`._

## Discord username (optional)

GrimLink#6075

## Name of theme

- snazzy
- snazzy_blue
- snazzy_green
- snazzy_red

_[Source repo](https://github.com/GrimLink/warp-theme-snazzy)_

## How Has This Been Tested?

Yes
