### PR TITLE
Add Classic Vivid color theme

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -13,6 +13,7 @@
 |**[Campbell](campbell.yaml)**:|<img src='previews/campbell.yaml.svg' width='300'>|
 |**[Catppuccin](catppuccin.yaml)**:|<img src='previews/catppuccin.yaml.svg' width='300'>|
 |**[Challenger Deep](challenger_deep.yaml)**:|<img src='previews/challenger_deep.yaml.svg' width='300'>|
+|**[Classic Vivid](classic_vivid.yaml)**:|<img src='previews/classic_vivid.yaml.svg' width='300'>|
 |**[Cobalt 2](cobalt_2.yaml)**:|<img src='previews/cobalt_2.yaml.svg' width='300'>|
 |**[Cobalt Next](cobalt_next.yaml)**:|<img src='previews/cobalt_next.yaml.svg' width='300'>|
 |**[Cyber Punk Neon](cyber_punk_neon.yaml)**:|<img src='previews/cyber_punk_neon.yaml.svg' width='300'>|

--- a/standard/classic_vivid.yaml
+++ b/standard/classic_vivid.yaml
@@ -1,0 +1,24 @@
+
+accent: '#00c3ff'
+background: '#000000'
+details: darker
+foreground: '#ffffff'
+terminal_colors:
+  bright:
+    black: '#888888'
+    blue: '#88ccff'
+    cyan: '#88ffff'
+    green: '#88ff88'
+    magenta: '#ff88ff'
+    red: '#ff8888'
+    white: '#ffffff'
+    yellow: '#ffff88'
+  normal:
+    black: '#000000'
+    blue: '#1190ff'
+    cyan: '#00fdfd'
+    green: '#00e000'
+    magenta: '#ff00ff'
+    red: '#ff0000'
+    white: '#dddddd'
+    yellow: '#fdfd00'

--- a/standard/previews/classic_vivid.yaml.svg
+++ b/standard/previews/classic_vivid.yaml.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145">
+<rect width="300" height="145" class="Dynamic" fill="#000000" rx="5" />
+
+<!-- first command -->
+<text x="15" y="15" fill="#ffffff" font-size="0.6em" font-family="monospace" class="Dynamic">ls</text>
+<text x="15" y="30" fill="#1190ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+dir
+</text>
+<text x="65" y="30" fill="#ff0000" font-size="0.6em" font-family="monospace" class="Dynamic">
+executable
+</text>
+<text x="175" y="30" fill="#ffffff" font-size="0.6em" font-family="monospace" class="Dynamic">
+file
+</text>
+<line x1="0" y1="40" x2="300" y2="40" style="stroke-width:0.2"  class="Dynamic" stroke="#ffffff"/>
+
+<!-- second command -->
+<text x="15" y="55" fill="#ffffff" font-size="0.6em" font-family="monospace" class="Dynamic">bash ~/colors.sh</text>
+<text x="15" y="70" fill="#ffffff" font-size="0.6em" font-family="monospace" class="Dynamic">
+normal:
+</text>
+<text x="55" y="70" fill="#000000" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="70" fill="#ff0000" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="70" fill="#00e000" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="70" fill="#fdfd00" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="70" fill="#1190ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="70" fill="#ff00ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="70" fill="#00fdfd" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="70" fill="#dddddd" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<text x="15" y="85" fill="#ffffff" font-size="0.6em" font-family="monospace" class='Dynamic'>
+bright:
+</text>
+<text x="55" y="85" fill="#888888" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="85" fill="#ff8888" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="85" fill="#88ff88" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="85" fill="#ffff88" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="85" fill="#88ccff" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="85" fill="#ff88ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="85" fill="#88ffff" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="85" fill="#ffffff" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<line x1="0" y1="95" x2="300" y2="95" style="stroke-width:0.2" class="Dynamic" stroke="#ffffff" />
+
+<!-- prompt -->
+<text x="15" y="110" fill="#ff00ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+~/project
+</text>
+<text x="65" y="110" fill="#00e000" font-size="0.6em" font-family="monospace" class="Dynamic">
+git(
+    </text>
+    <text x="85" y="110" fill="#fdfd00" font-size="0.6em" font-family="monospace" class="Dynamic">
+      main
+    </text>
+    <text x="113" y="110" fill="#00e000" font-size="0.6em" font-family="monospace" class="Dynamic">
+      )
+</text>
+<!-- cursor -->
+<line x1="15" y1="120" x2="15" y2="130" style="stroke-width:2" class="Dynamic" stroke="#00c3ff" />
+</svg>


### PR DESCRIPTION
# Pull Request Template

## Name of theme
Classic Vivid

## How Has This Been Tested?
In Warp, using various command line tools, npm, CommandBox (box system-colors), composer, etc.

Have you run the python script? `python3 ./scripts/gen_theme_previews.py <folder-name-eg-standard>`

Yes.

## Notes
Color theme incorporating "pure" colors from computers of yore, as used on MS-DOS or Unix command lines. Bright colors have noticeable contrast against normal colors. A few tweaks from pure colors improve contrast: for example, normal blue is lighter, normal green is darker.