### PR TITLE
feat: add port of vscode cherry theme

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -13,6 +13,7 @@
 |**[Campbell](campbell.yaml)**:|<img src='previews/campbell.yaml.svg' width='300'>|
 |**[Catppuccin](catppuccin.yaml)**:|<img src='previews/catppuccin.yaml.svg' width='300'>|
 |**[Challenger Deep](challenger_deep.yaml)**:|<img src='previews/challenger_deep.yaml.svg' width='300'>|
+|**[Cherry](cherry.yaml)**:|<img src='previews/cherry.yaml.svg' width='300'>|
 |**[Classic Vivid](classic_vivid.yaml)**:|<img src='previews/classic_vivid.yaml.svg' width='300'>|
 |**[Cobalt 2](cobalt_2.yaml)**:|<img src='previews/cobalt_2.yaml.svg' width='300'>|
 |**[Cobalt Next](cobalt_next.yaml)**:|<img src='previews/cobalt_next.yaml.svg' width='300'>|

--- a/standard/cherry.yaml
+++ b/standard/cherry.yaml
@@ -1,0 +1,25 @@
+# This is a port of the VSCode "Cherry" theme, extension id: nullxception.cherry-theme
+# Cherry theme is licensed under the MIT License (https://github.com/nullxception/cherry-vscode/blob/20d6b36e11c5666b674081fc9076d1ebdc6b3c56/LICENSE) and Copyright (c) 2020 Nauval Rizky
+accent: '#ff568e'
+background: '#23232f'
+details: darker
+foreground: '#bdc3c7'
+terminal_colors:
+  bright:
+    black: '#474756'
+    blue: '#94b9ff'
+    cyan: '#7cd7d5'
+    green: '#8be39e'
+    magenta: '#aa91f8'
+    red: '#ff84a6'
+    white: '#eaf0f4'
+    yellow: '#f1ff94'
+  normal:
+    black: '#3f3f4f'
+    blue: '#73a9ff'
+    cyan: '#46cfcc'
+    green: '#64de83'
+    magenta: '#946ff7'
+    red: '#ff568e'
+    white: '#dee5e9'
+    yellow: '#efff73'

--- a/standard/previews/cherry.yaml.svg
+++ b/standard/previews/cherry.yaml.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145">
+<rect width="300" height="145" class="Dynamic" fill="#23232f" rx="5" />
+
+<!-- first command -->
+<text x="15" y="15" fill="#bdc3c7" font-size="0.6em" font-family="monospace" class="Dynamic">ls</text>
+<text x="15" y="30" fill="#73a9ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+dir
+</text>
+<text x="65" y="30" fill="#ff568e" font-size="0.6em" font-family="monospace" class="Dynamic">
+executable
+</text>
+<text x="175" y="30" fill="#bdc3c7" font-size="0.6em" font-family="monospace" class="Dynamic">
+file
+</text>
+<line x1="0" y1="40" x2="300" y2="40" style="stroke-width:0.2"  class="Dynamic" stroke="#bdc3c7"/>
+
+<!-- second command -->
+<text x="15" y="55" fill="#bdc3c7" font-size="0.6em" font-family="monospace" class="Dynamic">bash ~/colors.sh</text>
+<text x="15" y="70" fill="#bdc3c7" font-size="0.6em" font-family="monospace" class="Dynamic">
+normal:
+</text>
+<text x="55" y="70" fill="#3f3f4f" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="70" fill="#ff568e" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="70" fill="#64de83" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="70" fill="#efff73" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="70" fill="#73a9ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="70" fill="#946ff7" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="70" fill="#46cfcc" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="70" fill="#dee5e9" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<text x="15" y="85" fill="#bdc3c7" font-size="0.6em" font-family="monospace" class='Dynamic'>
+bright:
+</text>
+<text x="55" y="85" fill="#474756" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="85" fill="#ff84a6" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="85" fill="#8be39e" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="85" fill="#f1ff94" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="85" fill="#94b9ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="85" fill="#aa91f8" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="85" fill="#7cd7d5" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="85" fill="#eaf0f4" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<line x1="0" y1="95" x2="300" y2="95" style="stroke-width:0.2" class="Dynamic" stroke="#bdc3c7" />
+
+<!-- prompt -->
+<text x="15" y="110" fill="#946ff7" font-size="0.6em" font-family="monospace" class="Dynamic">
+~/project
+</text>
+<text x="65" y="110" fill="#64de83" font-size="0.6em" font-family="monospace" class="Dynamic">
+git(
+    </text>
+    <text x="85" y="110" fill="#efff73" font-size="0.6em" font-family="monospace" class="Dynamic">
+      main
+    </text>
+    <text x="113" y="110" fill="#64de83" font-size="0.6em" font-family="monospace" class="Dynamic">
+      )
+</text>
+<!-- cursor -->
+<line x1="15" y1="120" x2="15" y2="130" style="stroke-width:2" class="Dynamic" stroke="#ff568e" />
+</svg>


### PR DESCRIPTION
## Name of theme

Cherry

## How Has This Been Tested?

I've run the preview script and tested it out in-app.

## Notes

This is a port of the Cherry VSCode theme, which is licensed under the MIT License. I've put a message at the top of the file, which is hopefully considered enough credit.