### PR TITLE
Add two themes

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -49,6 +49,8 @@
 |**[Lucario](lucario.yaml)**:|<img src='previews/lucario.yaml.svg' width='300'>|
 |**[Material Theme](material_theme.yaml)**:|<img src='previews/material_theme.yaml.svg' width='300'>|
 |**[Material Theme Mod](material_theme_mod.yaml)**:|<img src='previews/material_theme_mod.yaml.svg' width='300'>|
+|**[Matrix Dracula](matrix_dracula.yaml)**:|<img src='previews/matrix_dracula.yaml.svg' width='300'>|
+|**[Matrix Dracula Switcheroo](matrix_dracula_switcheroo.yaml)**:|<img src='previews/matrix_dracula_switcheroo.yaml.svg' width='300'>|
 |**[Monokai Pro](monokai_pro.yaml)**:|<img src='previews/monokai_pro.yaml.svg' width='300'>|
 |**[Monokai Pro Classic](monokai_pro_classic.yaml)**:|<img src='previews/monokai_pro_classic.yaml.svg' width='300'>|
 |**[Monokai Pro Machine](monokai_pro_machine.yaml)**:|<img src='previews/monokai_pro_machine.yaml.svg' width='300'>|

--- a/standard/matrix_dracula.yaml
+++ b/standard/matrix_dracula.yaml
@@ -1,0 +1,23 @@
+accent: "#00c2ff"
+background: "#282a36"
+foreground: "#00ff51"
+details: "darker"
+terminal_colors:
+  normal:
+    black: "#000000"
+    red: "#c91b00"
+    green: "#00c200"
+    yellow: "#c7c400"
+    blue: "#3650c2"
+    magenta: "#c930c7"
+    cyan: "#00c5c7"
+    white: "#c7c7c7"
+  bright:
+    black: "#676767"
+    red: "#ff6d67"
+    green: "#00f74e"
+    yellow: "#fefb67"
+    blue: "#6871ff"
+    magenta: "#ff76ff"
+    cyan: "#5ffdff"
+    white: "#fffefe"

--- a/standard/matrix_dracula_switcheroo.yaml
+++ b/standard/matrix_dracula_switcheroo.yaml
@@ -1,0 +1,23 @@
+accent: "#00c2ff"
+background: "#282a36"
+foreground: "#00ff51"
+details: "darker"
+terminal_colors:
+  normal:
+    black: "#000000"
+    red: "#c91b00"
+    green: "#6871ff"
+    yellow: "#ff6d67"
+    blue: "#3650c2"
+    magenta: "#5ffdff"
+    cyan: "#00c5c7"
+    white: "#c7c7c7"
+  bright:
+    black: "#676767"
+    red: "#ff6d67"
+    green: "#00f74e"
+    yellow: "#fefb67"
+    blue: "#6871ff"
+    magenta: "#ff76ff"
+    cyan: "#5ffdff"
+    white: "#fffefe"

--- a/standard/previews/matrix_dracula.yaml.svg
+++ b/standard/previews/matrix_dracula.yaml.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145">
+<rect width="300" height="145" class="Dynamic" fill="#282a36" rx="5" />
+
+<!-- first command -->
+<text x="15" y="15" fill="#00ff51" font-size="0.6em" font-family="monospace" class="Dynamic">ls</text>
+<text x="15" y="30" fill="#3650c2" font-size="0.6em" font-family="monospace" class="Dynamic">
+dir
+</text>
+<text x="65" y="30" fill="#c91b00" font-size="0.6em" font-family="monospace" class="Dynamic">
+executable
+</text>
+<text x="175" y="30" fill="#00ff51" font-size="0.6em" font-family="monospace" class="Dynamic">
+file
+</text>
+<line x1="0" y1="40" x2="300" y2="40" style="stroke-width:0.2"  class="Dynamic" stroke="#00ff51"/>
+
+<!-- second command -->
+<text x="15" y="55" fill="#00ff51" font-size="0.6em" font-family="monospace" class="Dynamic">bash ~/colors.sh</text>
+<text x="15" y="70" fill="#00ff51" font-size="0.6em" font-family="monospace" class="Dynamic">
+normal:
+</text>
+<text x="55" y="70" fill="#000000" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="70" fill="#c91b00" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="70" fill="#00c200" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="70" fill="#c7c400" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="70" fill="#3650c2" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="70" fill="#c930c7" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="70" fill="#00c5c7" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="70" fill="#c7c7c7" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<text x="15" y="85" fill="#00ff51" font-size="0.6em" font-family="monospace" class='Dynamic'>
+bright:
+</text>
+<text x="55" y="85" fill="#676767" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="85" fill="#ff6d67" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="85" fill="#00f74e" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="85" fill="#fefb67" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="85" fill="#6871ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="85" fill="#ff76ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="85" fill="#5ffdff" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="85" fill="#fffefe" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<line x1="0" y1="95" x2="300" y2="95" style="stroke-width:0.2" class="Dynamic" stroke="#00ff51" />
+
+<!-- prompt -->
+<text x="15" y="110" fill="#c930c7" font-size="0.6em" font-family="monospace" class="Dynamic">
+~/project
+</text>
+<text x="65" y="110" fill="#00c200" font-size="0.6em" font-family="monospace" class="Dynamic">
+git(
+    </text>
+    <text x="85" y="110" fill="#c7c400" font-size="0.6em" font-family="monospace" class="Dynamic">
+      main
+    </text>
+    <text x="113" y="110" fill="#00c200" font-size="0.6em" font-family="monospace" class="Dynamic">
+      )
+</text>
+<!-- cursor -->
+<line x1="15" y1="120" x2="15" y2="130" style="stroke-width:2" class="Dynamic" stroke="#00c2ff" />
+</svg>

--- a/standard/previews/matrix_dracula_switcheroo.yaml.svg
+++ b/standard/previews/matrix_dracula_switcheroo.yaml.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145">
+<rect width="300" height="145" class="Dynamic" fill="#282a36" rx="5" />
+
+<!-- first command -->
+<text x="15" y="15" fill="#00ff51" font-size="0.6em" font-family="monospace" class="Dynamic">ls</text>
+<text x="15" y="30" fill="#3650c2" font-size="0.6em" font-family="monospace" class="Dynamic">
+dir
+</text>
+<text x="65" y="30" fill="#c91b00" font-size="0.6em" font-family="monospace" class="Dynamic">
+executable
+</text>
+<text x="175" y="30" fill="#00ff51" font-size="0.6em" font-family="monospace" class="Dynamic">
+file
+</text>
+<line x1="0" y1="40" x2="300" y2="40" style="stroke-width:0.2"  class="Dynamic" stroke="#00ff51"/>
+
+<!-- second command -->
+<text x="15" y="55" fill="#00ff51" font-size="0.6em" font-family="monospace" class="Dynamic">bash ~/colors.sh</text>
+<text x="15" y="70" fill="#00ff51" font-size="0.6em" font-family="monospace" class="Dynamic">
+normal:
+</text>
+<text x="55" y="70" fill="#000000" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="70" fill="#c91b00" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="70" fill="#6871ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="70" fill="#ff6d67" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="70" fill="#3650c2" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="70" fill="#5ffdff" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="70" fill="#00c5c7" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="70" fill="#c7c7c7" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<text x="15" y="85" fill="#00ff51" font-size="0.6em" font-family="monospace" class='Dynamic'>
+bright:
+</text>
+<text x="55" y="85" fill="#676767" font-size="0.6em" font-family="monospace" class="Dynamic">
+black
+</text>
+<text x="85" y="85" fill="#ff6d67" font-size="0.6em" font-family="monospace" class="Dynamic">
+red
+</text>
+<text x="105" y="85" fill="#00f74e" font-size="0.6em" font-family="monospace" class="Dynamic">
+green
+</text>
+<text x="135" y="85" fill="#fefb67" font-size="0.6em" font-family="monospace" class="Dynamic">
+yellow
+</text>
+<text x="170" y="85" fill="#6871ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+blue
+</text>
+<text x="195" y="85" fill="#ff76ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+magenta
+</text>
+<text x="235" y="85" fill="#5ffdff" font-size="0.6em" font-family="monospace" class="Dynamic">
+cyan
+</text>
+<text x="260" y="85" fill="#fffefe" font-size="0.6em" font-family="monospace" class="Dynamic">
+white
+</text>
+<line x1="0" y1="95" x2="300" y2="95" style="stroke-width:0.2" class="Dynamic" stroke="#00ff51" />
+
+<!-- prompt -->
+<text x="15" y="110" fill="#5ffdff" font-size="0.6em" font-family="monospace" class="Dynamic">
+~/project
+</text>
+<text x="65" y="110" fill="#6871ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+git(
+    </text>
+    <text x="85" y="110" fill="#ff6d67" font-size="0.6em" font-family="monospace" class="Dynamic">
+      main
+    </text>
+    <text x="113" y="110" fill="#6871ff" font-size="0.6em" font-family="monospace" class="Dynamic">
+      )
+</text>
+<!-- cursor -->
+<line x1="15" y1="120" x2="15" y2="130" style="stroke-width:2" class="Dynamic" stroke="#00c2ff" />
+</svg>


### PR DESCRIPTION

## Discord username

`milkncookiez#1927`

## Name of theme
I'm adding two themes, which are very similar. The differences are only in the text colour of the default line showing the directory you're in and the git branch.

1. `matrix_dracula`
2. `matrix_dracula_switcheroo`

## How Has This Been Tested?

I ran the `python3 ./scripts/gen_theme_previews.py standard` script which generated the thumbnails and added them to the README.

I am also using the `_switcheroo` theme in my Warp app.

