### PR TITLE
feat: add Arc Dark theme

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -5,6 +5,7 @@
 | **[Afterglow](afterglow.yaml)**:                                      | <img src='previews/afterglow.yaml.svg' width='300'>                   |
 | **[Apple Dark](apple_dark.yaml)**:                                    | <img src='previews/apple_dark.yaml.svg' width='300'>                  |
 | **[Apple Light](apple_light.yaml)**:                                  | <img src='previews/apple_light.yaml.svg' width='300'>                 |
+| **[Arc Dark](arc_dark.yaml)**:                                        | <img src='previews/arc_dark.yaml.svg' width='300'>                    |
 | **[Argonaut](argonaut.yaml)**:                                        | <img src='previews/argonaut.yaml.svg' width='300'>                    |
 | **[Avirage](avirage.yaml)**:                                          | <img src='previews/avirage.yaml.svg' width='300'>                     |
 | **[Ayu Dark](ayu_dark.yaml)**:                                        | <img src='previews/ayu_dark.yaml.svg' width='300'>                    |

--- a/standard/arc_dark.yaml
+++ b/standard/arc_dark.yaml
@@ -1,0 +1,23 @@
+accent: '#009688'
+background: '#2f343f'
+details: darker
+foreground: '#d3dae3'
+terminal_colors:
+  bright:
+    black: '#2f343f'
+    red: '#d64937'
+    green: '#86df5d'
+    yellow: '#fdd75a'
+    blue: '#0f75bd'
+    magenta: '#9e5e83'
+    cyan: '#37c3d6'
+    white: '#f9f9f9'
+  normal:
+    black: '#262b36'
+    red: '#9c3528'
+    green: '#61bc3b'
+    yellow: '#f3b43a'
+    blue: '#0d68a8'
+    magenta: '#744560'
+    cyan: '#288e9c'
+    white: '#a2a2a2'

--- a/standard/previews/arc_dark.yaml.svg
+++ b/standard/previews/arc_dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#2f343f" class="Dynamic" rx="5"/><text x="15" y="15" fill="#d3dae3" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#0d68a8" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#9c3528" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#d3dae3" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#d3dae3" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#d3dae3" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#d3dae3" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#262b36" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#9c3528" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#61bc3b" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#f3b43a" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#0d68a8" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#744560" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#288e9c" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#a2a2a2" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#d3dae3" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#2f343f" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#d64937" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#86df5d" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#fdd75a" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#0f75bd" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#9e5e83" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#37c3d6" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f9f9f9" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#d3dae3" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#744560" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#61bc3b" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#f3b43a" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#61bc3b" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#009688" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION

# Pull Request Template

## Discord username (optional)

進藤ヒカル#6894

## Name of theme

Arc Dark

## How Has This Been Tested?

I ran python3 ./scripts/gen_theme_previews.py standard to generate the preview.

## Notes

Colours pulled from JetBrains Material UI plugin theme and this Gnome Terminal theme (https://gist.github.com/Kanon/99840108309ee3d2b995a0e5714f73ad)