### PR TITLE
Add Vitesse themes

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -97,6 +97,11 @@
 |**[Tokyo Night Storm](tokyo_night_storm.yaml)**:|<img src='previews/tokyo_night_storm.yaml.svg' width='300'>|
 |**[Tomorrow Night](tomorrow_night.yaml)**:|<img src='previews/tomorrow_night.yaml.svg' width='300'>|
 |**[Tomorrow Night Bright](tomorrow_night_bright.yaml)**:|<img src='previews/tomorrow_night_bright.yaml.svg' width='300'>|
+|**[Vitesse Black](vitesse_black.yaml)**:|<img src='previews/vitesse_black.yaml.svg' width='300'>|
+|**[Vitesse Dark](vitesse_dark.yaml)**:|<img src='previews/vitesse_dark.yaml.svg' width='300'>|
+|**[Vitesse Dark Soft](vitesse_dark_soft.yaml)**:|<img src='previews/vitesse_dark_soft.yaml.svg' width='300'>|
+|**[Vitesse Light](vitesse_light.yaml)**:|<img src='previews/vitesse_light.yaml.svg' width='300'>|
+|**[Vitesse Light Soft](vitesse_light_soft.yaml)**:|<img src='previews/vitesse_light_soft.yaml.svg' width='300'>|
 |**[Vscode Default Dark Material](vscode_default_dark_material.yml)**:|<img src='previews/vscode_default_dark_material.yml.svg' width='300'>|
 |**[Vuesion](vuesion.yaml)**:|<img src='previews/vuesion.yaml.svg' width='300'>|
 |**[Wombat](wombat.yaml)**:|<img src='previews/wombat.yaml.svg' width='300'>|

--- a/standard/previews/vitesse_black.yaml.svg
+++ b/standard/previews/vitesse_black.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#000" class="Dynamic" rx="5"/><text x="15" y="15" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#6394bf" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#cb7676" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#dbd7ca" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#777777" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#cb7676" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#4d9375" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#e6cc77" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#6394bf" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#d9739f" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#5eaab5" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#ffffff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#393a34" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#cb7676" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#4d9375" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#e6cc77" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#6394bf" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#d9739f" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#5eaab5" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#dbd7ca" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#d9739f" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#4d9375" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#e6cc77" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#4d9375" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#4d9375" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/vitesse_dark.yaml.svg
+++ b/standard/previews/vitesse_dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#121212" class="Dynamic" rx="5"/><text x="15" y="15" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#6394bf" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#cb7676" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#dbd7ca" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#777777" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#cb7676" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#4d9375" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#e6cc77" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#6394bf" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#d9739f" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#5eaab5" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#ffffff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#393a34" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#cb7676" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#4d9375" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#e6cc77" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#6394bf" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#d9739f" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#5eaab5" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#dbd7ca" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#d9739f" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#4d9375" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#e6cc77" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#4d9375" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#4d9375" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/vitesse_dark_soft.yaml.svg
+++ b/standard/previews/vitesse_dark_soft.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#222" class="Dynamic" rx="5"/><text x="15" y="15" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#6394bf" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#cb7676" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#dbd7ca" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#777777" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#cb7676" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#4d9375" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#e6cc77" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#6394bf" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#d9739f" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#5eaab5" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#ffffff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#393a34" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#cb7676" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#4d9375" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#e6cc77" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#6394bf" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#d9739f" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#5eaab5" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#dbd7ca" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#d9739f" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#4d9375" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#e6cc77" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#4d9375" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#4d9375" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/vitesse_light.yaml.svg
+++ b/standard/previews/vitesse_light.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#ffffff" class="Dynamic" rx="5"/><text x="15" y="15" fill="#393a34" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#296aa3" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#ab5959" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#393a34" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#393a34" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#393a34" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#393a34" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#aaaaaa" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#ab5959" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#1e754f" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#bda437" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#296aa3" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#a13865" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#2993a3" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#dddddd" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#393a34" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#121212" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ab5959" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#1e754f" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#bda437" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#296aa3" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#a13865" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#2993a3" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#393a34" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#a13865" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#1e754f" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#bda437" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#1e754f" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#1c6b48" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/vitesse_light_soft.yaml.svg
+++ b/standard/previews/vitesse_light_soft.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#F1F0E9" class="Dynamic" rx="5"/><text x="15" y="15" fill="#393a34" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#296aa3" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#ab5959" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#393a34" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#393a34" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#393a34" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#393a34" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#aaaaaa" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#ab5959" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#1e754f" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#bda437" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#296aa3" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#a13865" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#2993a3" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#dddddd" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#393a34" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#121212" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ab5959" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#1e754f" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#bda437" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#296aa3" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#a13865" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#2993a3" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#dbd7ca" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#393a34" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#a13865" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#1e754f" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#bda437" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#1e754f" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#1c6b48" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/vitesse_black.yaml
+++ b/standard/vitesse_black.yaml
@@ -1,0 +1,23 @@
+accent: "#4d9375"
+background: "#000"
+details: darker
+foreground: "#dbd7ca"
+terminal_colors:
+  bright:
+    black: "#393a34"
+    blue: "#6394bf"
+    cyan: "#5eaab5"
+    green: "#4d9375"
+    magenta: "#d9739f"
+    red: "#cb7676"
+    white: "#dbd7ca"
+    yellow: "#e6cc77"
+  normal:
+    black: "#777777"
+    blue: "#6394bf"
+    cyan: "#5eaab5"
+    green: "#4d9375"
+    magenta: "#d9739f"
+    red: "#cb7676"
+    white: "#ffffff"
+    yellow: "#e6cc77"

--- a/standard/vitesse_dark.yaml
+++ b/standard/vitesse_dark.yaml
@@ -1,0 +1,23 @@
+accent: "#4d9375"
+background: "#121212"
+details: darker
+foreground: "#dbd7ca"
+terminal_colors:
+  bright:
+    black: "#393a34"
+    blue: "#6394bf"
+    cyan: "#5eaab5"
+    green: "#4d9375"
+    magenta: "#d9739f"
+    red: "#cb7676"
+    white: "#dbd7ca"
+    yellow: "#e6cc77"
+  normal:
+    black: "#777777"
+    blue: "#6394bf"
+    cyan: "#5eaab5"
+    green: "#4d9375"
+    magenta: "#d9739f"
+    red: "#cb7676"
+    white: "#ffffff"
+    yellow: "#e6cc77"

--- a/standard/vitesse_dark_soft.yaml
+++ b/standard/vitesse_dark_soft.yaml
@@ -1,0 +1,23 @@
+accent: "#4d9375"
+background: "#222"
+details: darker
+foreground: "#dbd7ca"
+terminal_colors:
+  bright:
+    black: "#393a34"
+    blue: "#6394bf"
+    cyan: "#5eaab5"
+    green: "#4d9375"
+    magenta: "#d9739f"
+    red: "#cb7676"
+    white: "#dbd7ca"
+    yellow: "#e6cc77"
+  normal:
+    black: "#777777"
+    blue: "#6394bf"
+    cyan: "#5eaab5"
+    green: "#4d9375"
+    magenta: "#d9739f"
+    red: "#cb7676"
+    white: "#ffffff"
+    yellow: "#e6cc77"

--- a/standard/vitesse_light.yaml
+++ b/standard/vitesse_light.yaml
@@ -1,0 +1,23 @@
+accent: "#1c6b48"
+background: "#ffffff"
+details: lighter
+foreground: "#393a34"
+terminal_colors:
+  bright:
+    black: "#121212"
+    blue: "#296aa3"
+    cyan: "#2993a3"
+    green: "#1e754f"
+    magenta: "#a13865"
+    red: "#ab5959"
+    white: "#dbd7ca"
+    yellow: "#bda437"
+  normal:
+    black: "#aaaaaa"
+    blue: "#296aa3"
+    cyan: "#2993a3"
+    green: "#1e754f"
+    magenta: "#a13865"
+    red: "#ab5959"
+    white: "#dddddd"
+    yellow: "#bda437"

--- a/standard/vitesse_light_soft.yaml
+++ b/standard/vitesse_light_soft.yaml
@@ -1,0 +1,23 @@
+accent: "#1c6b48"
+background: "#F1F0E9"
+details: lighter
+foreground: "#393a34"
+terminal_colors:
+  bright:
+    black: "#121212"
+    blue: "#296aa3"
+    cyan: "#2993a3"
+    green: "#1e754f"
+    magenta: "#a13865"
+    red: "#ab5959"
+    white: "#dbd7ca"
+    yellow: "#bda437"
+  normal:
+    black: "#aaaaaa"
+    blue: "#296aa3"
+    cyan: "#2993a3"
+    green: "#1e754f"
+    magenta: "#a13865"
+    red: "#ab5959"
+    white: "#dddddd"
+    yellow: "#bda437"


### PR DESCRIPTION
## Name of theme

The included themes are the following:

- [Vitesse Black](https://user-images.githubusercontent.com/494699/216093478-b14d6487-4ea2-46e2-8cd9-4138e36fc21c.png)
- [Vitesse Dark](https://user-images.githubusercontent.com/494699/216093571-651a4e38-517f-4cf9-bfc8-c9611250173b.png)
- [Vitesse Dark Soft](https://user-images.githubusercontent.com/494699/216093524-0fd93538-50fc-48fc-b100-24172e166645.png)
- [Vitesse Light](https://user-images.githubusercontent.com/494699/216093687-4550e30c-c951-4255-9d2c-3cda6669d402.png)
- [Vitesse Light Soft](https://user-images.githubusercontent.com/494699/216093633-60c818ec-701e-4ff1-bcf0-ae29e4a37359.png)

## How Has This Been Tested?

I did run the python script using the `python3 ./scripts/gen_theme_previews.py standard` command.

I also tested the themes locally in Warp.

## Notes

There is no custom background images in these themes.

The themes have been developed in https://github.com/HiDeoo/warp-theme-vitesse and are based on the [Vitesse Theme for VS Code](https://github.com/antfu/vscode-theme-vitesse).