### PR TITLE
Feature/json schema for themes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v3
       - run: pip3 install jsonschema-cli
       - run: |
-          for directory in base16 holiday standard; do
+          for directory in base16 holiday standard warp_bundled; do
             env -C "$directory" jsonschema-cli validate "../schemas/theme.json" *.yaml
           done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: pip3 install jsonschema-cli
+      - run: |
+          for directory in base16 holiday standard; do
+            env -C "$directory" jsonschema-cli validate "../schemas/theme.json" *.yaml
+          done

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "yaml.schemas": {
+        "schemas/theme.json": [
+            "base16/*.yaml",
+            "holiday/*.yaml"
+        ]
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,8 @@
         "schemas/theme.json": [
             "base16/*.yaml",
             "holiday/*.yaml",
-            "standard/*.yaml"
+            "standard/*.yaml",
+            "warp_bundled/*.yaml"
         ]
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,8 @@
     "yaml.schemas": {
         "schemas/theme.json": [
             "base16/*.yaml",
-            "holiday/*.yaml"
+            "holiday/*.yaml",
+            "standard/*.yaml"
         ]
     }
 }

--- a/schemas/theme.json
+++ b/schemas/theme.json
@@ -86,9 +86,9 @@
                         },
                         {
                             "properties": {
-                                "up": {
-                                    "title": "up",
-                                    "description": "A up color",
+                                "top": {
+                                    "title": "top",
+                                    "description": "A top color",
                                     "$ref": "#/definitions/color"
                                 },
                                 "bottom": {

--- a/schemas/theme.json
+++ b/schemas/theme.json
@@ -20,42 +20,42 @@
             "properties": {
                 "black": {
                     "title": "black",
-                    "description": "A black color of the current theme",
+                    "description": "A black color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
                     "$ref": "#/definitions/color"
                 },
                 "blue": {
                     "title": "blue",
-                    "description": "A blue color of the current theme",
+                    "description": "A blue color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
                     "$ref": "#/definitions/color"
                 },
                 "cyan": {
                     "title": "cyan",
-                    "description": "A cyan color of the current theme",
+                    "description": "A cyan color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
                     "$ref": "#/definitions/color"
                 },
                 "green": {
                     "title": "green",
-                    "description": "A green color of the current theme",
+                    "description": "A green color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
                     "$ref": "#/definitions/color"
                 },
                 "magenta": {
                     "title": "magenta",
-                    "description": "A magenta color of the current theme",
+                    "description": "A magenta color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
                     "$ref": "#/definitions/color"
                 },
                 "red": {
                     "title": "red",
-                    "description": "A red color of the current theme",
+                    "description": "A red color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
                     "$ref": "#/definitions/color"
                 },
                 "white": {
                     "title": "white",
-                    "description": "A white color of the current theme",
+                    "description": "A white color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
                     "$ref": "#/definitions/color"
                 },
                 "yellow": {
                     "title": "yellow",
-                    "description": "A yellow color of the current theme",
+                    "description": "A yellow color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
                     "$ref": "#/definitions/color"
                 }
             },
@@ -73,12 +73,12 @@
                             "properties": {
                                 "left": {
                                     "title": "left",
-                                    "description": "A left color of the current theme",
+                                    "description": "A left color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#background-images-and-gradients",
                                     "$ref": "#/definitions/color"
                                 },
                                 "right": {
                                     "title": "right",
-                                    "description": "A right color of the current theme",
+                                    "description": "A right color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#background-images-and-gradients",
                                     "$ref": "#/definitions/color"
                                 }
                             },
@@ -88,12 +88,12 @@
                             "properties": {
                                 "top": {
                                     "title": "top",
-                                    "description": "A top color of the current theme",
+                                    "description": "A top color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#background-images-and-gradients",
                                     "$ref": "#/definitions/color"
                                 },
                                 "bottom": {
                                     "title": "bottom",
-                                    "description": "A bottom color of the current theme",
+                                    "description": "A bottom color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#background-images-and-gradients",
                                     "$ref": "#/definitions/color"
                                 }
                             },
@@ -110,17 +110,17 @@
     "properties": {
         "accent": {
             "title": "accent",
-            "description": "An accent color of the current theme",
+            "description": "An accent color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
             "$ref": "#/definitions/color-or-gradient"
         },
         "background": {
             "title": "background",
-            "description": "A background color of the current theme",
+            "description": "A background color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
             "$ref": "#/definitions/color-or-gradient"
         },
         "details": {
             "title": "details",
-            "description": "Whether lighter or darker colors are used in the current theme",
+            "description": "Whether lighter or darker colors are used in the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
             "type": "string",
             "enum": [
                 "lighter",
@@ -129,22 +129,22 @@
         },
         "foreground": {
             "title": "foreground",
-            "description": "A foreground color of the current theme",
+            "description": "A foreground color of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
             "$ref": "#/definitions/color"
         },
         "terminal_colors": {
             "title": "terminal colors",
-            "description": "Terminal colors of the current theme",
+            "description": "Terminal colors of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
             "type": "object",
             "properties": {
                 "bright": {
                     "title": "bright",
-                    "description": "Bright colors of the current theme",
+                    "description": "Bright colors of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
                     "$ref": "#/definitions/colors"
                 },
                 "normal": {
                     "title": "normal",
-                    "description": "Normal colors of the current theme",
+                    "description": "Normal colors of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#create-your-own-custom-theme-manually",
                     "$ref": "#/definitions/colors"
                 }
             },
@@ -157,7 +157,7 @@
             "properties": {
                 "path": {
                     "title": "path",
-                    "description": "A path of the current image of the current theme",
+                    "description": "A path of the current image of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#background-images-and-gradients",
                     "type": "string",
                     "minLength": 1,
                     "examples": [
@@ -166,7 +166,7 @@
                 },
                 "opacity": {
                     "title": "opacity",
-                    "description": "An opacity of the current image of the current theme",
+                    "description": "An opacity of the current image of the current theme\nhttps://docs.warp.dev/appearance/custom-themes#background-images-and-gradients",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100

--- a/schemas/theme.json
+++ b/schemas/theme.json
@@ -1,0 +1,179 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "definitions": {
+        "color": {
+            "type": "string",
+            "pattern": "^#[0-9a-fA-F]{6}$",
+            "examples": [
+                "#000000",
+                "#ff0000",
+                "#00ff00",
+                "#0000ff",
+                "#ffff00",
+                "#ff00ff",
+                "#00ffff",
+                "#ffffff"
+            ]
+        },
+        "colors": {
+            "type": "object",
+            "properties": {
+                "black": {
+                    "title": "black",
+                    "description": "A black color",
+                    "$ref": "#/definitions/color"
+                },
+                "blue": {
+                    "title": "blue",
+                    "description": "A blue color",
+                    "$ref": "#/definitions/color"
+                },
+                "cyan": {
+                    "title": "cyan",
+                    "description": "A cyan color",
+                    "$ref": "#/definitions/color"
+                },
+                "green": {
+                    "title": "green",
+                    "description": "A green color",
+                    "$ref": "#/definitions/color"
+                },
+                "magenta": {
+                    "title": "magenta",
+                    "description": "A magenta color",
+                    "$ref": "#/definitions/color"
+                },
+                "red": {
+                    "title": "red",
+                    "description": "A red color",
+                    "$ref": "#/definitions/color"
+                },
+                "white": {
+                    "title": "white",
+                    "description": "A white color",
+                    "$ref": "#/definitions/color"
+                },
+                "yellow": {
+                    "title": "yellow",
+                    "description": "A yellow color",
+                    "$ref": "#/definitions/color"
+                }
+            },
+            "additionalProperties": false
+        },
+        "color-or-gradient": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/color"
+                },
+                {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "left": {
+                                    "title": "left",
+                                    "description": "A left color",
+                                    "$ref": "#/definitions/color"
+                                },
+                                "right": {
+                                    "title": "right",
+                                    "description": "A right color",
+                                    "$ref": "#/definitions/color"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        {
+                            "properties": {
+                                "up": {
+                                    "title": "up",
+                                    "description": "A up color",
+                                    "$ref": "#/definitions/color"
+                                },
+                                "bottom": {
+                                    "title": "bottom",
+                                    "description": "A bottom color",
+                                    "$ref": "#/definitions/color"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "title": "theme",
+    "description": "A theme",
+    "type": "object",
+    "properties": {
+        "accent": {
+            "title": "accent",
+            "description": "An accent color",
+            "$ref": "#/definitions/color-or-gradient"
+        },
+        "background": {
+            "title": "background",
+            "description": "A background color",
+            "$ref": "#/definitions/color-or-gradient"
+        },
+        "details": {
+            "title": "details",
+            "description": "Whether lighter or darker colors are used",
+            "type": "string",
+            "enum": [
+                "lighter",
+                "darker"
+            ]
+        },
+        "foreground": {
+            "title": "foreground",
+            "description": "A foreground color",
+            "$ref": "#/definitions/color"
+        },
+        "terminal_colors": {
+            "title": "terminal colors",
+            "description": "Terminal colors",
+            "type": "object",
+            "properties": {
+                "bright": {
+                    "title": "bright",
+                    "description": "Bright colors",
+                    "$ref": "#/definitions/colors"
+                },
+                "normal": {
+                    "title": "normal",
+                    "description": "Normal colors",
+                    "$ref": "#/definitions/colors"
+                }
+            },
+            "additionalProperties": false
+        },
+        "background_image": {
+            "title": "background image",
+            "description": "A background image",
+            "type": "object",
+            "properties": {
+                "path": {
+                    "title": "path",
+                    "description": "A path of the current image",
+                    "type": "string",
+                    "minLength": 1,
+                    "examples": [
+                        "warp.jpg"
+                    ]
+                },
+                "opacity": {
+                    "title": "opacity",
+                    "description": "An opacity of the current image",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false
+}

--- a/schemas/theme.json
+++ b/schemas/theme.json
@@ -20,42 +20,42 @@
             "properties": {
                 "black": {
                     "title": "black",
-                    "description": "A black color",
+                    "description": "A black color of the current theme",
                     "$ref": "#/definitions/color"
                 },
                 "blue": {
                     "title": "blue",
-                    "description": "A blue color",
+                    "description": "A blue color of the current theme",
                     "$ref": "#/definitions/color"
                 },
                 "cyan": {
                     "title": "cyan",
-                    "description": "A cyan color",
+                    "description": "A cyan color of the current theme",
                     "$ref": "#/definitions/color"
                 },
                 "green": {
                     "title": "green",
-                    "description": "A green color",
+                    "description": "A green color of the current theme",
                     "$ref": "#/definitions/color"
                 },
                 "magenta": {
                     "title": "magenta",
-                    "description": "A magenta color",
+                    "description": "A magenta color of the current theme",
                     "$ref": "#/definitions/color"
                 },
                 "red": {
                     "title": "red",
-                    "description": "A red color",
+                    "description": "A red color of the current theme",
                     "$ref": "#/definitions/color"
                 },
                 "white": {
                     "title": "white",
-                    "description": "A white color",
+                    "description": "A white color of the current theme",
                     "$ref": "#/definitions/color"
                 },
                 "yellow": {
                     "title": "yellow",
-                    "description": "A yellow color",
+                    "description": "A yellow color of the current theme",
                     "$ref": "#/definitions/color"
                 }
             },
@@ -73,12 +73,12 @@
                             "properties": {
                                 "left": {
                                     "title": "left",
-                                    "description": "A left color",
+                                    "description": "A left color of the current theme",
                                     "$ref": "#/definitions/color"
                                 },
                                 "right": {
                                     "title": "right",
-                                    "description": "A right color",
+                                    "description": "A right color of the current theme",
                                     "$ref": "#/definitions/color"
                                 }
                             },
@@ -88,12 +88,12 @@
                             "properties": {
                                 "top": {
                                     "title": "top",
-                                    "description": "A top color",
+                                    "description": "A top color of the current theme",
                                     "$ref": "#/definitions/color"
                                 },
                                 "bottom": {
                                     "title": "bottom",
-                                    "description": "A bottom color",
+                                    "description": "A bottom color of the current theme",
                                     "$ref": "#/definitions/color"
                                 }
                             },
@@ -110,17 +110,17 @@
     "properties": {
         "accent": {
             "title": "accent",
-            "description": "An accent color",
+            "description": "An accent color of the current theme",
             "$ref": "#/definitions/color-or-gradient"
         },
         "background": {
             "title": "background",
-            "description": "A background color",
+            "description": "A background color of the current theme",
             "$ref": "#/definitions/color-or-gradient"
         },
         "details": {
             "title": "details",
-            "description": "Whether lighter or darker colors are used",
+            "description": "Whether lighter or darker colors are used in the current theme",
             "type": "string",
             "enum": [
                 "lighter",
@@ -129,22 +129,22 @@
         },
         "foreground": {
             "title": "foreground",
-            "description": "A foreground color",
+            "description": "A foreground color of the current theme",
             "$ref": "#/definitions/color"
         },
         "terminal_colors": {
             "title": "terminal colors",
-            "description": "Terminal colors",
+            "description": "Terminal colors of the current theme",
             "type": "object",
             "properties": {
                 "bright": {
                     "title": "bright",
-                    "description": "Bright colors",
+                    "description": "Bright colors of the current theme",
                     "$ref": "#/definitions/colors"
                 },
                 "normal": {
                     "title": "normal",
-                    "description": "Normal colors",
+                    "description": "Normal colors of the current theme",
                     "$ref": "#/definitions/colors"
                 }
             },
@@ -152,12 +152,12 @@
         },
         "background_image": {
             "title": "background image",
-            "description": "A background image",
+            "description": "A background image of the current theme",
             "type": "object",
             "properties": {
                 "path": {
                     "title": "path",
-                    "description": "A path of the current image",
+                    "description": "A path of the current image of the current theme",
                     "type": "string",
                     "minLength": 1,
                     "examples": [
@@ -166,7 +166,7 @@
                 },
                 "opacity": {
                     "title": "opacity",
-                    "description": "An opacity of the current image",
+                    "description": "An opacity of the current image of the current theme",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100


### PR DESCRIPTION
# Pull Request Template

## Discord username (optional)

If you're in our Discord server, we'd like to give you the Contributor Discord Role, please include
your username. Note: It must be labelled like so: username#4747 (make sure to include the #XXXX).

`Emily Grace Seville#9556`

## Name of theme

null

## How Has This Been Tested?

Have you run the python script? `python3 ./scripts/gen_theme_previews.py <folder-name-eg-standard>`

## Notes

We cannot accept pull request that include custom background images because:

- of licensing restrictions
- we are trying to keep the binary size of the repo as small as possible (just the yaml files)

If your theme has an intended custom background image, include a comment in the yaml with a link to
where people should download it.

## Screenshots

![image](https://github.com/warpdotdev/themes/assets/42812113/4c632704-192d-4211-aa51-d9f5f250cb37)

![image](https://github.com/warpdotdev/themes/assets/42812113/336a452f-48b4-4d05-9687-467a244b78ca)

![image](https://github.com/warpdotdev/themes/assets/42812113/0620b3e3-8c55-426f-8917-f0e31831b2eb)

## Notes

Intellisence is enabled now for all themes so anybody can take advantage of it while creating new themes.

YAML Red Hat extension is required to be able to use hints and validate themes on the fly.
