### PR TITLE
Create light and dark themes based on Pop!_OS

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -56,6 +56,7 @@
 |**[Iceberg](iceberg.yaml)**:|<img src='previews/iceberg.yaml.svg' width='300'>|
 |**[Iterm](iterm.yaml)**:|<img src='previews/iterm.yaml.svg' width='300'>|
 |**[Jellybeans](jellybeans.yaml)**:|<img src='previews/jellybeans.yaml.svg' width='300'>|
+|**[Kanagawa](kanagawa.yaml)**:|<img src='previews/kanagawa.yaml.svg' width='300'>|
 |**[Konsole Linux](konsole_linux.yaml)**:|<img src='previews/konsole_linux.yaml.svg' width='300'>|
 |**[Laser](laser.yaml)**:|<img src='previews/laser.yaml.svg' width='300'>|
 |**[Light-pinkish](light-pinkish.yaml)**:|<img src='previews/light-pinkish.yaml.svg' width='300'>|
@@ -89,6 +90,8 @@
 |**[Plastic](plastic.yaml)**:|<img src='previews/plastic.yaml.svg' width='300'>|
 |**[Poimandres](poimandres.yaml)**:|<img src='previews/poimandres.yaml.svg' width='300'>|
 |**[Poimandres Alt](poimandres_alt.yaml)**:|<img src='previews/poimandres_alt.yaml.svg' width='300'>|
+|**[Popos Dark](popos_dark.yaml)**:|<img src='previews/popos_dark.yaml.svg' width='300'>|
+|**[Popos Light](popos_light.yaml)**:|<img src='previews/popos_light.yaml.svg' width='300'>|
 |**[Remedy Dark](remedy_dark.yaml)**:|<img src='previews/remedy_dark.yaml.svg' width='300'>|
 |**[Seashells](seashells.yaml)**:|<img src='previews/seashells.yaml.svg' width='300'>|
 |**[Shades Of Purple](shades_of_purple.yaml)**:|<img src='previews/shades_of_purple.yaml.svg' width='300'>|

--- a/standard/popos_dark.yaml
+++ b/standard/popos_dark.yaml
@@ -1,0 +1,23 @@
+accent: "#FFAD00"
+background: "#2B2928"
+foreground: "#63B1BC"
+details: "darker"
+terminal_colors:
+  normal:
+    black: "#000"
+    red: "#EA9090"
+    green: "#82BF8C"
+    yellow: "#FEDB40"
+    blue: "#63B1BC"
+    magenta: "#CF7DFF"
+    cyan: "#3E88FF"
+    white: "#FFF"
+  bright:
+    black: "#111"
+    red: "#E56A54"
+    green: "#90CFB0"
+    yellow: "#FFF19E"
+    blue: "#6ACAD8"
+    magenta: "#D58CFF"
+    cyan: "#95C4FC"
+    white: "#EEE"

--- a/standard/popos_light.yaml
+++ b/standard/popos_light.yaml
@@ -1,0 +1,23 @@
+accent: "#FBB86C"
+background: "#FCFCFC"
+foreground: "#6ACAD8"
+details: "lighter"
+terminal_colors:
+  normal:
+    black: "#000"
+    red: "#EA9090"
+    green: "#90CFB0"
+    yellow: "#F9D87A"
+    blue: "#6ACAD8"
+    magenta: "#D58CFF"
+    cyan: "#95C4FC"
+    white: "#FFF"
+  bright:
+    black: "#111"
+    red: "#E56A54"
+    green: "#82BF8C"
+    yellow: "#FEDB40"
+    blue: "#63B1BC"
+    magenta: "#CF7DFF"
+    cyan: "#5689E7"
+    white: "#EEE"

--- a/standard/previews/popos_dark.yaml.svg
+++ b/standard/previews/popos_dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#2B2928" class="Dynamic" rx="5"/><text x="15" y="15" fill="#63B1BC" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#63B1BC" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#EA9090" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#63B1BC" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#63B1BC" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#63B1BC" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#63B1BC" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#000" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#EA9090" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#82BF8C" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#FEDB40" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#63B1BC" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#CF7DFF" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#3E88FF" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#FFF" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#63B1BC" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#111" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#E56A54" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#90CFB0" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#FFF19E" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#6ACAD8" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#D58CFF" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#95C4FC" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#EEE" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#63B1BC" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#CF7DFF" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#82BF8C" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#FEDB40" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#82BF8C" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#FFAD00" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/popos_light.yaml.svg
+++ b/standard/previews/popos_light.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#FCFCFC" class="Dynamic" rx="5"/><text x="15" y="15" fill="#6ACAD8" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#6ACAD8" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#EA9090" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#6ACAD8" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#6ACAD8" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#6ACAD8" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#6ACAD8" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#000" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#EA9090" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#90CFB0" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#F9D87A" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#6ACAD8" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#D58CFF" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#95C4FC" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#FFF" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#6ACAD8" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#111" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#E56A54" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#82BF8C" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#FEDB40" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#63B1BC" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#CF7DFF" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#5689E7" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#EEE" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#6ACAD8" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#D58CFF" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#90CFB0" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#F9D87A" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#90CFB0" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#FBB86C" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
# Pull Request Template

## Discord username (optional)

If you're in our Discord server, we'd like to give you the Contributor Discord Role, please include your username. Note: It must be labelled like so: username#4747 (make sure to include the #XXXX).

zimapurple

NB: Didn't discord depreceate the numbering system recently? Mine might have been 76884?

## Name of theme

popos_light
popos_dark

## How Has This Been Tested?

Have you run the python script? `python3 ./scripts/gen_theme_previews.py <folder-name-eg-standard>`

Yes

## Notes

We cannot accept pull request that include custom background images because:

- of licensing restrictions
- we are trying to keep the binary size of the repo as small as possible (just the yaml files)

If your theme has an intended custom background image, include a comment in the yaml with a link to where people should download it.
