### PR TITLE
add Base2Tone dark theme files and generated previews

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -10,6 +10,26 @@
 |**[Ayu Light](ayu_light.yaml)**:|<img src='previews/ayu_light.yaml.svg' width='300'>|
 |**[Ayu Mirage](ayu_mirage.yaml)**:|<img src='previews/ayu_mirage.yaml.svg' width='300'>|
 |**[Azuki](azuki.yaml)**:|<img src='previews/azuki.yaml.svg' width='300'>|
+|**[Base2tone-cave-dark](base2tone-cave-dark.yaml)**:|<img src='previews/base2tone-cave-dark.yaml.svg' width='300'>|
+|**[Base2tone-desert-dark](base2tone-desert-dark.yaml)**:|<img src='previews/base2tone-desert-dark.yaml.svg' width='300'>|
+|**[Base2tone-drawbridge-dark](base2tone-drawbridge-dark.yaml)**:|<img src='previews/base2tone-drawbridge-dark.yaml.svg' width='300'>|
+|**[Base2tone-earth-dark](base2tone-earth-dark.yaml)**:|<img src='previews/base2tone-earth-dark.yaml.svg' width='300'>|
+|**[Base2tone-evening-dark](base2tone-evening-dark.yaml)**:|<img src='previews/base2tone-evening-dark.yaml.svg' width='300'>|
+|**[Base2tone-field-dark](base2tone-field-dark.yaml)**:|<img src='previews/base2tone-field-dark.yaml.svg' width='300'>|
+|**[Base2tone-forest-dark](base2tone-forest-dark.yaml)**:|<img src='previews/base2tone-forest-dark.yaml.svg' width='300'>|
+|**[Base2tone-garden-dark](base2tone-garden-dark.yaml)**:|<img src='previews/base2tone-garden-dark.yaml.svg' width='300'>|
+|**[Base2tone-heath-dark](base2tone-heath-dark.yaml)**:|<img src='previews/base2tone-heath-dark.yaml.svg' width='300'>|
+|**[Base2tone-lake-dark](base2tone-lake-dark.yaml)**:|<img src='previews/base2tone-lake-dark.yaml.svg' width='300'>|
+|**[Base2tone-lavender-dark](base2tone-lavender-dark.yaml)**:|<img src='previews/base2tone-lavender-dark.yaml.svg' width='300'>|
+|**[Base2tone-mall-dark](base2tone-mall-dark.yaml)**:|<img src='previews/base2tone-mall-dark.yaml.svg' width='300'>|
+|**[Base2tone-meadow-dark](base2tone-meadow-dark.yaml)**:|<img src='previews/base2tone-meadow-dark.yaml.svg' width='300'>|
+|**[Base2tone-morning-dark](base2tone-morning-dark.yaml)**:|<img src='previews/base2tone-morning-dark.yaml.svg' width='300'>|
+|**[Base2tone-motel-dark](base2tone-motel-dark.yaml)**:|<img src='previews/base2tone-motel-dark.yaml.svg' width='300'>|
+|**[Base2tone-pool-dark](base2tone-pool-dark.yaml)**:|<img src='previews/base2tone-pool-dark.yaml.svg' width='300'>|
+|**[Base2tone-porch-dark](base2tone-porch-dark.yaml)**:|<img src='previews/base2tone-porch-dark.yaml.svg' width='300'>|
+|**[Base2tone-sea-dark](base2tone-sea-dark.yaml)**:|<img src='previews/base2tone-sea-dark.yaml.svg' width='300'>|
+|**[Base2tone-space-dark](base2tone-space-dark.yaml)**:|<img src='previews/base2tone-space-dark.yaml.svg' width='300'>|
+|**[Base2tone-suburb-dark](base2tone-suburb-dark.yaml)**:|<img src='previews/base2tone-suburb-dark.yaml.svg' width='300'>|
 |**[Bilibili Dark](bilibili_dark.yaml)**:|<img src='previews/bilibili_dark.yaml.svg' width='300'>|
 |**[Blood Moon](blood_moon.yaml)**:|<img src='previews/blood_moon.yaml.svg' width='300'>|
 |**[Blue Monday](blue_monday.yaml)**:|<img src='previews/blue_monday.yaml.svg' width='300'>|

--- a/standard/base2tone-cave-dark.yaml
+++ b/standard/base2tone-cave-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Cave Dark
+accent: '#996e00'
+background: '#222021'
+foreground: '#9f999b'
+details: darker
+terminal_colors:
+  normal:
+    black: '#222021'
+    red: '#936c7a'
+    green: '#cca133'
+    yellow: '#ffcc4d'
+    blue: '#9c818b'
+    magenta: '#cca133'
+    cyan: '#d27998'
+    white: '#9f999b'
+  bright:
+    black: '#635f60'
+    red: '#ddaf3c'
+    green: '#2f2d2e'
+    yellow: '#565254'
+    blue: '#706b6d'
+    magenta: '#f0a8c1'
+    cyan: '#c39622'
+    white: '#ffebf2'

--- a/standard/base2tone-desert-dark.yaml
+++ b/standard/base2tone-desert-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Desert Dark
+accent: '#bc672f'
+background: '#292724'
+foreground: '#ada594'
+details: darker
+terminal_colors:
+  normal:
+    black: '#292724'
+    red: '#816f4b'
+    green: '#ec9255'
+    yellow: '#ffb380'
+    blue: '#957e50'
+    magenta: '#ec9255'
+    cyan: '#ac8e53'
+    white: '#ada594'
+  bright:
+    black: '#7e7767'
+    red: '#f29d63'
+    green: '#3d3a34'
+    yellow: '#615c51'
+    blue: '#908774'
+    magenta: '#ddcba6'
+    cyan: '#e58748'
+    white: '#f2ead9'

--- a/standard/base2tone-drawbridge-dark.yaml
+++ b/standard/base2tone-drawbridge-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Drawbridge Dark
+accent: '#289dbd'
+background: '#1b1f32'
+foreground: '#9094a7'
+details: darker
+terminal_colors:
+  normal:
+    black: '#1b1f32'
+    red: '#627af4'
+    green: '#67c9e4'
+    yellow: '#99e9ff'
+    blue: '#7289fd'
+    magenta: '#67c9e4'
+    cyan: '#8b9efd'
+    white: '#9094a7'
+  bright:
+    black: '#51587b'
+    red: '#75d5f0'
+    green: '#252a41'
+    yellow: '#444b6f'
+    blue: '#5e6587'
+    magenta: '#c3cdfe'
+    cyan: '#5cbcd6'
+    white: '#e1e6ff'

--- a/standard/base2tone-earth-dark.yaml
+++ b/standard/base2tone-earth-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Earth Dark
+accent: '#9c8349'
+background: '#322d29'
+foreground: '#b5a9a1'
+details: darker
+terminal_colors:
+  normal:
+    black: '#322d29'
+    red: '#816d5f'
+    green: '#d9b154'
+    yellow: '#fcc440'
+    blue: '#88786d'
+    magenta: '#d9b154'
+    cyan: '#967e6e'
+    white: '#b5a9a1'
+  bright:
+    black: '#6a5f58'
+    red: '#e6b84d'
+    green: '#3f3a37'
+    yellow: '#5b534d'
+    blue: '#796b63'
+    magenta: '#dfb99f'
+    cyan: '#cda956'
+    white: '#fff3eb'

--- a/standard/base2tone-evening-dark.yaml
+++ b/standard/base2tone-evening-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Evening Dark
+accent: '#b37537'
+background: '#2a2734'
+foreground: '#a4a1b5'
+details: darker
+terminal_colors:
+  normal:
+    black: '#2a2734'
+    red: '#8a75f5'
+    green: '#ffad5c'
+    yellow: '#ffcc99'
+    blue: '#9a86fd'
+    magenta: '#ffad5c'
+    cyan: '#afa0fe'
+    white: '#a4a1b5'
+  bright:
+    black: '#6c6783'
+    red: '#ffb870'
+    green: '#363342'
+    yellow: '#545167'
+    blue: '#787391'
+    magenta: '#d9d2fe'
+    cyan: '#ffa142'
+    white: '#eeebff'

--- a/standard/base2tone-field-dark.yaml
+++ b/standard/base2tone-field-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Field Dark
+accent: '#00943e'
+background: '#18201e'
+foreground: '#8ea4a0'
+details: darker
+terminal_colors:
+  normal:
+    black: '#18201e'
+    red: '#0fbda0'
+    green: '#3be381'
+    yellow: '#85ffb8'
+    blue: '#25d0b4'
+    magenta: '#3be381'
+    cyan: '#40ddc3'
+    white: '#8ea4a0'
+  bright:
+    black: '#5a6d6a'
+    red: '#55ec94'
+    green: '#242e2c'
+    yellow: '#42524f'
+    blue: '#667a77'
+    magenta: '#88f2e0'
+    cyan: '#25d46e'
+    white: '#a8fff1'

--- a/standard/base2tone-forest-dark.yaml
+++ b/standard/base2tone-forest-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Forest Dark
+accent: '#a2b34d'
+background: '#2a2d2a'
+foreground: '#a1b5a1'
+details: darker
+terminal_colors:
+  normal:
+    black: '#2a2d2a'
+    red: '#5c705c'
+    green: '#bfd454'
+    yellow: '#e5fb79'
+    blue: '#687d68'
+    magenta: '#bfd454'
+    cyan: '#8fae8f'
+    white: '#a1b5a1'
+  bright:
+    black: '#535f53'
+    red: '#cbe25a'
+    green: '#353b35'
+    yellow: '#485148'
+    blue: '#5e6e5e'
+    magenta: '#c8e4c8'
+    cyan: '#b1c44f'
+    white: '#f0fff0'

--- a/standard/base2tone-garden-dark.yaml
+++ b/standard/base2tone-garden-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Garden Dark
+accent: '#bd5d0f'
+background: '#1e1f1e'
+foreground: '#969c96'
+details: darker
+terminal_colors:
+  normal:
+    black: '#1e1f1e'
+    red: '#3fac39'
+    green: '#db9257'
+    yellow: '#e0cab8'
+    blue: '#4cb946'
+    magenta: '#db9257'
+    cyan: '#6bcc66'
+    white: '#969c96'
+  bright:
+    black: '#5d605c'
+    red: '#dba070'
+    green: '#2b2c2a'
+    yellow: '#505350'
+    blue: '#696d69'
+    magenta: '#b7e3b5'
+    cyan: '#dd843c'
+    white: '#dcf0db'

--- a/standard/base2tone-heath-dark.yaml
+++ b/standard/base2tone-heath-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Heath Dark
+accent: '#995900'
+background: '#222022'
+foreground: '#9e999f'
+details: darker
+terminal_colors:
+  normal:
+    black: '#222022'
+    red: '#8f6c93'
+    green: '#cc8c33'
+    yellow: '#ffd599'
+    blue: '#9a819c'
+    magenta: '#cc8c33'
+    cyan: '#cb79d2'
+    white: '#9e999f'
+  bright:
+    black: '#635f63'
+    red: '#d9b98c'
+    green: '#2f2d2f'
+    yellow: '#575158'
+    blue: '#6f6b70'
+    magenta: '#eaa8f0'
+    cyan: '#c38022'
+    white: '#fdebff'

--- a/standard/base2tone-lake-dark.yaml
+++ b/standard/base2tone-lake-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Lake Dark
+accent: '#84740b'
+background: '#192d34'
+foreground: '#7ba8b7'
+details: darker
+terminal_colors:
+  normal:
+    black: '#192d34'
+    red: '#3e91ac'
+    green: '#cbbb4d'
+    yellow: '#ffeb66'
+    blue: '#499fbc'
+    magenta: '#cbbb4d'
+    cyan: '#62b1cb'
+    white: '#7ba8b7'
+  bright:
+    black: '#3d6876'
+    red: '#d6c65c'
+    green: '#223c44'
+    yellow: '#335966'
+    blue: '#467686'
+    magenta: '#a5d8e9'
+    cyan: '#c4b031'
+    white: '#e1f7ff'

--- a/standard/base2tone-lavender-dark.yaml
+++ b/standard/base2tone-lavender-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Lavender Dark
+accent: '#b042ff'
+background: '#201d2a'
+foreground: '#9992b0'
+details: darker
+terminal_colors:
+  normal:
+    black: '#201d2a'
+    red: '#9375f5'
+    green: '#d294ff'
+    yellow: '#ecd1ff'
+    blue: '#a286fd'
+    magenta: '#d294ff'
+    cyan: '#b5a0fe'
+    white: '#9992b0'
+  bright:
+    black: '#625a7c'
+    red: '#dba8ff'
+    green: '#2c2839'
+    yellow: '#4b455f'
+    blue: '#6e658b'
+    magenta: '#dcd2fe'
+    cyan: '#ca80ff'
+    white: '#efebff'

--- a/standard/base2tone-mall-dark.yaml
+++ b/standard/base2tone-mall-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Mall Dark
+accent: '#3692e2'
+background: '#1e1e1f'
+foreground: '#97959d'
+details: darker
+terminal_colors:
+  normal:
+    black: '#1e1e1f'
+    red: '#a17efc'
+    green: '#75bfff'
+    yellow: '#b3dbff'
+    blue: '#b294ff'
+    magenta: '#75bfff'
+    cyan: '#c5adff'
+    white: '#97959d'
+  bright:
+    black: '#5e5c60'
+    red: '#8ac8ff'
+    green: '#2b2b2c'
+    yellow: '#515053'
+    blue: '#6a686e'
+    magenta: '#e5dbff'
+    cyan: '#69b5f7'
+    white: '#f4f0ff'

--- a/standard/base2tone-meadow-dark.yaml
+++ b/standard/base2tone-meadow-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Meadow Dark
+accent: '#4d8217'
+background: '#192834'
+foreground: '#7b9eb7'
+details: darker
+terminal_colors:
+  normal:
+    black: '#192834'
+    red: '#277fbe'
+    green: '#80bf40'
+    yellow: '#a6f655'
+    blue: '#4299d7'
+    magenta: '#80bf40'
+    cyan: '#47adf5'
+    white: '#7b9eb7'
+  bright:
+    black: '#3d5e76'
+    red: '#8cdd3c'
+    green: '#223644'
+    yellow: '#335166'
+    blue: '#466b86'
+    magenta: '#afddfe'
+    cyan: '#73b234'
+    white: '#d1ecff'

--- a/standard/base2tone-morning-dark.yaml
+++ b/standard/base2tone-morning-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Morning Dark
+accent: '#896724'
+background: '#232834'
+foreground: '#8d95a5'
+details: darker
+terminal_colors:
+  normal:
+    black: '#232834'
+    red: '#1659df'
+    green: '#b29762'
+    yellow: '#e5ddcd'
+    blue: '#3d75e6'
+    magenta: '#b29762'
+    cyan: '#728fcb'
+    white: '#8d95a5'
+  bright:
+    black: '#656e81'
+    red: '#c6b28b'
+    green: '#31363f'
+    yellow: '#4f5664'
+    blue: '#707a8f'
+    magenta: '#b7c9eb'
+    cyan: '#9a7c42'
+    white: '#dee6f7'

--- a/standard/base2tone-motel-dark.yaml
+++ b/standard/base2tone-motel-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Motel Dark
+accent: '#e24f32'
+background: '#242323'
+foreground: '#a5979a'
+details: darker
+terminal_colors:
+  normal:
+    black: '#242323'
+    red: '#956f76'
+    green: '#f8917c'
+    yellow: '#ffc8bd'
+    blue: '#a7868b'
+    magenta: '#f8917c'
+    cyan: '#b89da2'
+    white: '#a5979a'
+  bright:
+    black: '#766b6c'
+    red: '#ffa28f'
+    green: '#373434'
+    yellow: '#5a5354'
+    blue: '#86797b'
+    magenta: '#dec9cc'
+    cyan: '#f77c64'
+    white: '#f0dbdf'

--- a/standard/base2tone-pool-dark.yaml
+++ b/standard/base2tone-pool-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Pool Dark
+accent: '#cf504a'
+background: '#2a2433'
+foreground: '#9a90a7'
+details: darker
+terminal_colors:
+  normal:
+    black: '#2a2433'
+    red: '#aa75f5'
+    green: '#f87972'
+    yellow: '#ffb6b3'
+    blue: '#b886fd'
+    magenta: '#f87972'
+    cyan: '#c7a0fe'
+    white: '#9a90a7'
+  bright:
+    black: '#635775'
+    red: '#fc8983'
+    green: '#372f42'
+    yellow: '#574b68'
+    blue: '#706383'
+    magenta: '#e4d2fe'
+    cyan: '#f36f68'
+    white: '#f3ebff'

--- a/standard/base2tone-porch-dark.yaml
+++ b/standard/base2tone-porch-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Porch Dark
+accent: '#c46731'
+background: '#221e24'
+foreground: '#9f95a3'
+details: darker
+terminal_colors:
+  normal:
+    black: '#221e24'
+    red: '#9466a3'
+    green: '#f39b68'
+    yellow: '#ffc29e'
+    blue: '#a77cb6'
+    magenta: '#f39b68'
+    cyan: '#ba95c6'
+    white: '#9f95a3'
+  bright:
+    black: '#645a68'
+    red: '#f8aa7c'
+    green: '#302a32'
+    yellow: '#574e5a'
+    blue: '#716774'
+    magenta: '#dfcbe6'
+    cyan: '#ec8d55'
+    white: '#f2e3f7'

--- a/standard/base2tone-sea-dark.yaml
+++ b/standard/base2tone-sea-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Sea Dark
+accent: '#067953'
+background: '#1d262f'
+foreground: '#a1aab5'
+details: darker
+terminal_colors:
+  normal:
+    black: '#1d262f'
+    red: '#34659d'
+    green: '#0fc78a'
+    yellow: '#47ebb4'
+    blue: '#57718e'
+    magenta: '#0fc78a'
+    cyan: '#6e9bcf'
+    white: '#a1aab5'
+  bright:
+    black: '#4a5f78'
+    red: '#14e19d'
+    green: '#27323f'
+    yellow: '#405368'
+    blue: '#738191'
+    magenta: '#afd4fe'
+    cyan: '#0db57d'
+    white: '#ebf4ff'

--- a/standard/base2tone-space-dark.yaml
+++ b/standard/base2tone-space-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Space Dark
+accent: '#b25424'
+background: '#24242e'
+foreground: '#a1a1b5'
+details: darker
+terminal_colors:
+  normal:
+    black: '#24242e'
+    red: '#7676f4'
+    green: '#ec7336'
+    yellow: '#fe8c52'
+    blue: '#767693'
+    magenta: '#ec7336'
+    cyan: '#8a8aad'
+    white: '#a1a1b5'
+  bright:
+    black: '#5b5b76'
+    red: '#f37b3f'
+    green: '#333342'
+    yellow: '#515167'
+    blue: '#737391'
+    magenta: '#cecee3'
+    cyan: '#e66e33'
+    white: '#ebebff'

--- a/standard/base2tone-suburb-dark.yaml
+++ b/standard/base2tone-suburb-dark.yaml
@@ -1,0 +1,24 @@
+name: Base2Tone Suburb Dark
+accent: '#d14781'
+background: '#1e202f'
+foreground: '#878ba6'
+details: darker
+terminal_colors:
+  normal:
+    black: '#1e202f'
+    red: '#7586f5'
+    green: '#fb6fa9'
+    yellow: '#ffb3d2'
+    blue: '#8696fd'
+    magenta: '#fb6fa9'
+    cyan: '#a0acfe'
+    white: '#878ba6'
+  bright:
+    black: '#4f5472'
+    red: '#fe81b5'
+    green: '#292c3d'
+    yellow: '#444864'
+    blue: '#5b6080'
+    magenta: '#d2d8fe'
+    cyan: '#f764a1'
+    white: '#ebedff'

--- a/standard/previews/base2tone-cave-dark.yaml.svg
+++ b/standard/previews/base2tone-cave-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#222021" class="Dynamic" rx="5"/><text x="15" y="15" fill="#9f999b" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#9c818b" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#936c7a" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#9f999b" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#9f999b" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#9f999b" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#9f999b" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#222021" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#936c7a" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#cca133" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#ffcc4d" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#9c818b" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#cca133" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#d27998" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#9f999b" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#9f999b" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#635f60" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ddaf3c" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#2f2d2e" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#565254" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#706b6d" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#f0a8c1" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#c39622" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#ffebf2" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#9f999b" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#cca133" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#cca133" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#ffcc4d" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#cca133" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#996e00" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-desert-dark.yaml.svg
+++ b/standard/previews/base2tone-desert-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#292724" class="Dynamic" rx="5"/><text x="15" y="15" fill="#ada594" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#957e50" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#816f4b" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#ada594" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#ada594" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#ada594" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#ada594" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#292724" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#816f4b" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#ec9255" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#ffb380" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#957e50" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#ec9255" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#ac8e53" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#ada594" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#ada594" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#7e7767" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#f29d63" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#3d3a34" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#615c51" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#908774" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#ddcba6" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#e58748" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f2ead9" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#ada594" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#ec9255" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#ec9255" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#ffb380" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#ec9255" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#bc672f" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-drawbridge-dark.yaml.svg
+++ b/standard/previews/base2tone-drawbridge-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#1b1f32" class="Dynamic" rx="5"/><text x="15" y="15" fill="#9094a7" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#7289fd" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#627af4" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#9094a7" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#9094a7" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#9094a7" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#9094a7" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1b1f32" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#627af4" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#67c9e4" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#99e9ff" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#7289fd" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#67c9e4" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#8b9efd" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#9094a7" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#9094a7" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#51587b" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#75d5f0" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#252a41" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#444b6f" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#5e6587" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#c3cdfe" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#5cbcd6" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#e1e6ff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#9094a7" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#67c9e4" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#67c9e4" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#99e9ff" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#67c9e4" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#289dbd" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-earth-dark.yaml.svg
+++ b/standard/previews/base2tone-earth-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#322d29" class="Dynamic" rx="5"/><text x="15" y="15" fill="#b5a9a1" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#88786d" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#816d5f" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#b5a9a1" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#b5a9a1" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#b5a9a1" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#b5a9a1" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#322d29" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#816d5f" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#d9b154" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#fcc440" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#88786d" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#d9b154" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#967e6e" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#b5a9a1" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#b5a9a1" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#6a5f58" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#e6b84d" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#3f3a37" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#5b534d" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#796b63" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#dfb99f" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#cda956" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#fff3eb" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#b5a9a1" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#d9b154" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#d9b154" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#fcc440" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#d9b154" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#9c8349" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-evening-dark.yaml.svg
+++ b/standard/previews/base2tone-evening-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#2a2734" class="Dynamic" rx="5"/><text x="15" y="15" fill="#a4a1b5" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#9a86fd" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#8a75f5" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#a4a1b5" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#a4a1b5" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#a4a1b5" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#a4a1b5" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#2a2734" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#8a75f5" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#ffad5c" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#ffcc99" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#9a86fd" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#ffad5c" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#afa0fe" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#a4a1b5" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#a4a1b5" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#6c6783" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ffb870" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#363342" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#545167" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#787391" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#d9d2fe" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#ffa142" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#eeebff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#a4a1b5" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#ffad5c" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#ffad5c" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#ffcc99" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#ffad5c" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#b37537" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-field-dark.yaml.svg
+++ b/standard/previews/base2tone-field-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#18201e" class="Dynamic" rx="5"/><text x="15" y="15" fill="#8ea4a0" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#25d0b4" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#0fbda0" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#8ea4a0" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#8ea4a0" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#8ea4a0" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#8ea4a0" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#18201e" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#0fbda0" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#3be381" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#85ffb8" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#25d0b4" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#3be381" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#40ddc3" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#8ea4a0" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#8ea4a0" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#5a6d6a" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#55ec94" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#242e2c" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#42524f" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#667a77" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#88f2e0" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#25d46e" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#a8fff1" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#8ea4a0" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#3be381" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#3be381" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#85ffb8" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#3be381" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#00943e" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-forest-dark.yaml.svg
+++ b/standard/previews/base2tone-forest-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#2a2d2a" class="Dynamic" rx="5"/><text x="15" y="15" fill="#a1b5a1" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#687d68" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#5c705c" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#a1b5a1" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#a1b5a1" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#a1b5a1" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#a1b5a1" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#2a2d2a" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#5c705c" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#bfd454" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#e5fb79" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#687d68" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#bfd454" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#8fae8f" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#a1b5a1" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#a1b5a1" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#535f53" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#cbe25a" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#353b35" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#485148" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#5e6e5e" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#c8e4c8" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#b1c44f" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f0fff0" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#a1b5a1" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#bfd454" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#bfd454" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#e5fb79" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#bfd454" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#a2b34d" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-garden-dark.yaml.svg
+++ b/standard/previews/base2tone-garden-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#1e1f1e" class="Dynamic" rx="5"/><text x="15" y="15" fill="#969c96" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#4cb946" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#3fac39" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#969c96" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#969c96" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#969c96" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#969c96" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1e1f1e" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#3fac39" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#db9257" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#e0cab8" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#4cb946" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#db9257" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#6bcc66" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#969c96" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#969c96" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#5d605c" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#dba070" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#2b2c2a" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#505350" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#696d69" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#b7e3b5" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#dd843c" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#dcf0db" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#969c96" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#db9257" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#db9257" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#e0cab8" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#db9257" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#bd5d0f" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-heath-dark.yaml.svg
+++ b/standard/previews/base2tone-heath-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#222022" class="Dynamic" rx="5"/><text x="15" y="15" fill="#9e999f" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#9a819c" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#8f6c93" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#9e999f" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#9e999f" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#9e999f" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#9e999f" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#222022" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#8f6c93" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#cc8c33" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#ffd599" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#9a819c" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#cc8c33" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#cb79d2" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#9e999f" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#9e999f" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#635f63" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#d9b98c" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#2f2d2f" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#575158" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#6f6b70" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#eaa8f0" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#c38022" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#fdebff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#9e999f" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#cc8c33" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#cc8c33" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#ffd599" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#cc8c33" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#995900" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-lake-dark.yaml.svg
+++ b/standard/previews/base2tone-lake-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#192d34" class="Dynamic" rx="5"/><text x="15" y="15" fill="#7ba8b7" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#499fbc" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#3e91ac" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#7ba8b7" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#7ba8b7" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#7ba8b7" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#7ba8b7" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#192d34" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#3e91ac" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#cbbb4d" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#ffeb66" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#499fbc" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#cbbb4d" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#62b1cb" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#7ba8b7" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#7ba8b7" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#3d6876" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#d6c65c" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#223c44" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#335966" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#467686" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#a5d8e9" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#c4b031" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#e1f7ff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#7ba8b7" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#cbbb4d" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#cbbb4d" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#ffeb66" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#cbbb4d" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#84740b" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-lavender-dark.yaml.svg
+++ b/standard/previews/base2tone-lavender-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#201d2a" class="Dynamic" rx="5"/><text x="15" y="15" fill="#9992b0" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#a286fd" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#9375f5" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#9992b0" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#9992b0" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#9992b0" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#9992b0" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#201d2a" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#9375f5" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#d294ff" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#ecd1ff" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#a286fd" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#d294ff" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#b5a0fe" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#9992b0" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#9992b0" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#625a7c" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#dba8ff" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#2c2839" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#4b455f" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#6e658b" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#dcd2fe" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#ca80ff" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#efebff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#9992b0" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#d294ff" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#d294ff" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#ecd1ff" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#d294ff" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#b042ff" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-mall-dark.yaml.svg
+++ b/standard/previews/base2tone-mall-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#1e1e1f" class="Dynamic" rx="5"/><text x="15" y="15" fill="#97959d" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#b294ff" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#a17efc" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#97959d" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#97959d" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#97959d" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#97959d" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1e1e1f" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#a17efc" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#75bfff" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#b3dbff" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#b294ff" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#75bfff" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#c5adff" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#97959d" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#97959d" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#5e5c60" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#8ac8ff" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#2b2b2c" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#515053" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#6a686e" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#e5dbff" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#69b5f7" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f4f0ff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#97959d" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#75bfff" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#75bfff" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#b3dbff" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#75bfff" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#3692e2" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-meadow-dark.yaml.svg
+++ b/standard/previews/base2tone-meadow-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#192834" class="Dynamic" rx="5"/><text x="15" y="15" fill="#7b9eb7" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#4299d7" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#277fbe" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#7b9eb7" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#7b9eb7" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#7b9eb7" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#7b9eb7" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#192834" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#277fbe" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#80bf40" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#a6f655" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#4299d7" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#80bf40" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#47adf5" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#7b9eb7" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#7b9eb7" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#3d5e76" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#8cdd3c" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#223644" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#335166" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#466b86" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#afddfe" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#73b234" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#d1ecff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#7b9eb7" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#80bf40" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#80bf40" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#a6f655" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#80bf40" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#4d8217" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-morning-dark.yaml.svg
+++ b/standard/previews/base2tone-morning-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#232834" class="Dynamic" rx="5"/><text x="15" y="15" fill="#8d95a5" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#3d75e6" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#1659df" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#8d95a5" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#8d95a5" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#8d95a5" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#8d95a5" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#232834" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#1659df" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#b29762" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#e5ddcd" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#3d75e6" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#b29762" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#728fcb" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#8d95a5" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#8d95a5" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#656e81" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#c6b28b" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#31363f" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#4f5664" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#707a8f" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#b7c9eb" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#9a7c42" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#dee6f7" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#8d95a5" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#b29762" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#b29762" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#e5ddcd" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#b29762" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#896724" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-motel-dark.yaml.svg
+++ b/standard/previews/base2tone-motel-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#242323" class="Dynamic" rx="5"/><text x="15" y="15" fill="#a5979a" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#a7868b" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#956f76" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#a5979a" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#a5979a" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#a5979a" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#a5979a" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#242323" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#956f76" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#f8917c" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#ffc8bd" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#a7868b" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#f8917c" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#b89da2" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#a5979a" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#a5979a" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#766b6c" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ffa28f" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#373434" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#5a5354" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#86797b" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#dec9cc" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#f77c64" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f0dbdf" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#a5979a" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#f8917c" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#f8917c" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#ffc8bd" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#f8917c" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#e24f32" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-pool-dark.yaml.svg
+++ b/standard/previews/base2tone-pool-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#2a2433" class="Dynamic" rx="5"/><text x="15" y="15" fill="#9a90a7" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#b886fd" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#aa75f5" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#9a90a7" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#9a90a7" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#9a90a7" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#9a90a7" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#2a2433" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#aa75f5" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#f87972" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#ffb6b3" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#b886fd" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#f87972" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#c7a0fe" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#9a90a7" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#9a90a7" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#635775" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#fc8983" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#372f42" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#574b68" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#706383" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#e4d2fe" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#f36f68" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f3ebff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#9a90a7" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#f87972" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#f87972" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#ffb6b3" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#f87972" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#cf504a" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-porch-dark.yaml.svg
+++ b/standard/previews/base2tone-porch-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#221e24" class="Dynamic" rx="5"/><text x="15" y="15" fill="#9f95a3" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#a77cb6" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#9466a3" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#9f95a3" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#9f95a3" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#9f95a3" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#9f95a3" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#221e24" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#9466a3" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#f39b68" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#ffc29e" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#a77cb6" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#f39b68" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#ba95c6" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#9f95a3" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#9f95a3" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#645a68" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#f8aa7c" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#302a32" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#574e5a" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#716774" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#dfcbe6" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#ec8d55" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f2e3f7" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#9f95a3" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#f39b68" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#f39b68" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#ffc29e" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#f39b68" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#c46731" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-sea-dark.yaml.svg
+++ b/standard/previews/base2tone-sea-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#1d262f" class="Dynamic" rx="5"/><text x="15" y="15" fill="#a1aab5" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#57718e" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#34659d" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#a1aab5" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#a1aab5" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#a1aab5" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#a1aab5" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1d262f" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#34659d" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#0fc78a" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#47ebb4" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#57718e" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#0fc78a" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#6e9bcf" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#a1aab5" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#a1aab5" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#4a5f78" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#14e19d" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#27323f" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#405368" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#738191" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#afd4fe" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#0db57d" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#ebf4ff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#a1aab5" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#0fc78a" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#0fc78a" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#47ebb4" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#0fc78a" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#067953" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-space-dark.yaml.svg
+++ b/standard/previews/base2tone-space-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#24242e" class="Dynamic" rx="5"/><text x="15" y="15" fill="#a1a1b5" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#767693" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#7676f4" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#a1a1b5" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#a1a1b5" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#a1a1b5" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#a1a1b5" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#24242e" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#7676f4" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#ec7336" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#fe8c52" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#767693" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#ec7336" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#8a8aad" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#a1a1b5" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#a1a1b5" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#5b5b76" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#f37b3f" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#333342" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#515167" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#737391" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#cecee3" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#e66e33" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#ebebff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#a1a1b5" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#ec7336" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#ec7336" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#fe8c52" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#ec7336" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#b25424" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base2tone-suburb-dark.yaml.svg
+++ b/standard/previews/base2tone-suburb-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#1e202f" class="Dynamic" rx="5"/><text x="15" y="15" fill="#878ba6" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#8696fd" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#7586f5" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#878ba6" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#878ba6" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#878ba6" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#878ba6" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1e202f" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#7586f5" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#fb6fa9" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#ffb3d2" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#8696fd" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#fb6fa9" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#a0acfe" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#878ba6" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#878ba6" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#4f5472" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#fe81b5" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#292c3d" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#444864" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#5b6080" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#d2d8fe" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#f764a1" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#ebedff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#878ba6" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#fb6fa9" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#fb6fa9" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#ffb3d2" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#fb6fa9" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#d14781" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
# Pull Request for Base2Tone themes

## Base2Tone

## This has been tested
I have run the python script

## Notes
These are the dark duotone themes of [Base2Tone](https://base2t.one). If people would like to use the light variations of these themes they can find them at [github.com/atelierbram/Base2Tone-warp](https://github.com/atelierbram/Base2Tone-warp).

