### PR TITLE
add some Base4Tone dark theme files and generated previews

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -10,6 +10,13 @@
 |**[Ayu Light](ayu_light.yaml)**:|<img src='previews/ayu_light.yaml.svg' width='300'>|
 |**[Ayu Mirage](ayu_mirage.yaml)**:|<img src='previews/ayu_mirage.yaml.svg' width='300'>|
 |**[Azuki](azuki.yaml)**:|<img src='previews/azuki.yaml.svg' width='300'>|
+|**[Base4tone-classic-d-dark](base4tone-classic-d-dark.yaml)**:|<img src='previews/base4tone-classic-d-dark.yaml.svg' width='300'>|
+|**[Base4tone-classic-i-dark](base4tone-classic-i-dark.yaml)**:|<img src='previews/base4tone-classic-i-dark.yaml.svg' width='300'>|
+|**[Base4tone-classic-p-dark](base4tone-classic-p-dark.yaml)**:|<img src='previews/base4tone-classic-p-dark.yaml.svg' width='300'>|
+|**[Base4tone-classic-s-dark](base4tone-classic-s-dark.yaml)**:|<img src='previews/base4tone-classic-s-dark.yaml.svg' width='300'>|
+|**[Base4tone-classic-w-dark](base4tone-classic-w-dark.yaml)**:|<img src='previews/base4tone-classic-w-dark.yaml.svg' width='300'>|
+|**[Base4tone-modern-n-dark](base4tone-modern-n-dark.yaml)**:|<img src='previews/base4tone-modern-n-dark.yaml.svg' width='300'>|
+|**[Base4tone-modern-w-dark](base4tone-modern-w-dark.yaml)**:|<img src='previews/base4tone-modern-w-dark.yaml.svg' width='300'>|
 |**[Bilibili Dark](bilibili_dark.yaml)**:|<img src='previews/bilibili_dark.yaml.svg' width='300'>|
 |**[Blood Moon](blood_moon.yaml)**:|<img src='previews/blood_moon.yaml.svg' width='300'>|
 |**[Blue Monday](blue_monday.yaml)**:|<img src='previews/blue_monday.yaml.svg' width='300'>|

--- a/standard/base4tone-classic-d-dark.yaml
+++ b/standard/base4tone-classic-d-dark.yaml
@@ -1,0 +1,24 @@
+name: Base4Tone_Classic_D Dark
+accent: '#da6b2b'
+background: '#21211c'
+foreground: '#a2a090'
+details: darker
+terminal_colors:
+  normal:
+    black: '#21211c'
+    red: '#049582'
+    green: '#da6b2b'
+    yellow: '#ee9968'
+    blue: '#cfb617'
+    magenta: '#82c115'
+    cyan: '#e6854d'
+    white: '#eeede8'
+  bright:
+    black: '#0d0c07'
+    red: '#1cc4ae'
+    green: '#f0a57a'
+    yellow: '#f5c1a3'
+    blue: '#f6edb1'
+    magenta: '#95dc18'
+    cyan: '#f2e58c'
+    white: '#f9f8f6'

--- a/standard/base4tone-classic-i-dark.yaml
+++ b/standard/base4tone-classic-i-dark.yaml
@@ -1,0 +1,24 @@
+name: Base4Tone_Classic_I Dark
+accent: '#91a404'
+background: '#1d201d'
+foreground: '#949e95'
+details: darker
+terminal_colors:
+  normal:
+    black: '#1d201d'
+    red: '#5c6feb'
+    green: '#91a404'
+    yellow: '#c5dc18'
+    blue: '#24cc38'
+    magenta: '#23b4c7'
+    cyan: '#adc115'
+    white: '#e8ede9'
+  bright:
+    black: '#080d08'
+    red: '#929ff7'
+    green: '#cee61a'
+    yellow: '#e6f28c'
+    blue: '#b5f2bc'
+    magenta: '#3ccadd'
+    cyan: '#97eda1'
+    white: '#f6f9f6'

--- a/standard/base4tone-classic-p-dark.yaml
+++ b/standard/base4tone-classic-p-dark.yaml
@@ -1,0 +1,24 @@
+name: Base4Tone_Classic_P Dark
+accent: '#1398aa'
+background: '#1c1d21'
+foreground: '#9092a2'
+details: darker
+terminal_colors:
+  normal:
+    black: '#1c1d21'
+    red: '#c039d5'
+    green: '#1398aa'
+    yellow: '#3ccadd'
+    blue: '#929ff7'
+    magenta: '#a57af0'
+    cyan: '#23b4c7'
+    white: '#e8e8ee'
+  bright:
+    black: '#07080d'
+    red: '#db75eb'
+    green: '#5ad2e2'
+    yellow: '#a4e6ef'
+    blue: '#d0d5fb'
+    magenta: '#b792f6'
+    cyan: '#c6cdfb'
+    white: '#f6f6f9'

--- a/standard/base4tone-classic-s-dark.yaml
+++ b/standard/base4tone-classic-s-dark.yaml
@@ -1,0 +1,24 @@
+name: Base4Tone_Classic_S Dark
+accent: '#7e70e6'
+background: '#1f1d20'
+foreground: '#9a949e'
+details: darker
+terminal_colors:
+  normal:
+    black: '#1f1d20'
+    red: '#d64f3d'
+    green: '#7e70e6'
+    yellow: '#aba1f7'
+    blue: '#c27eed'
+    magenta: '#e963b8'
+    cyan: '#9488f2'
+    white: '#ebe8ed'
+  bright:
+    black: '#0b070d'
+    red: '#eb8275'
+    green: '#b7aff8'
+    yellow: '#d1cbfb'
+    blue: '#e6c8f9'
+    magenta: '#f17ec7'
+    cyan: '#e0baf7'
+    white: '#f8f6f9'

--- a/standard/base4tone-classic-w-dark.yaml
+++ b/standard/base4tone-classic-w-dark.yaml
@@ -1,0 +1,24 @@
+name: Base4Tone_Classic_W Dark
+accent: '#ca45de'
+background: '#201d1e'
+foreground: '#9e9498'
+details: darker
+terminal_colors:
+  normal:
+    black: '#201d1e'
+    red: '#b87305'
+    green: '#ca45de'
+    yellow: '#e17ef1'
+    blue: '#eb75a2'
+    magenta: '#e97263'
+    cyan: '#d763e9'
+    white: '#ede8ea'
+  bright:
+    black: '#0d080a'
+    red: '#e6971a'
+    green: '#e691f3'
+    yellow: '#edb1f6'
+    blue: '#f8bfd5'
+    magenta: '#f18c7e'
+    cyan: '#f6b1cc'
+    white: '#f9f6f7'

--- a/standard/base4tone-modern-n-dark.yaml
+++ b/standard/base4tone-modern-n-dark.yaml
@@ -1,0 +1,24 @@
+name: Base4Tone_Modern_N Dark
+accent: '#a48f04'
+background: '#1a2023'
+foreground: '#8a9da8'
+details: darker
+terminal_colors:
+  normal:
+    black: '#1a2023'
+    red: '#d53975'
+    green: '#a48f04'
+    yellow: '#dcc218'
+    blue: '#47b5f5'
+    magenta: '#8493f6'
+    cyan: '#c1aa15'
+    white: '#e8ebee'
+  bright:
+    black: '#070b0d'
+    red: '#eb75a2'
+    green: '#e6ca1a'
+    yellow: '#f2e58c'
+    blue: '#bbe4fb'
+    magenta: '#a0acf8'
+    cyan: '#b1e0fb'
+    white: '#f6f8f9'

--- a/standard/base4tone-modern-w-dark.yaml
+++ b/standard/base4tone-modern-w-dark.yaml
@@ -1,0 +1,24 @@
+name: Base4Tone_Modern_W Dark
+accent: '#1398aa'
+background: '#201d1e'
+foreground: '#9e9498'
+details: darker
+terminal_colors:
+  normal:
+    black: '#201d1e'
+    red: '#21a00d'
+    green: '#1398aa'
+    yellow: '#3ccadd'
+    blue: '#eb75a2'
+    magenta: '#e97263'
+    cyan: '#23b4c7'
+    white: '#ede8ea'
+  bright:
+    black: '#0d080a'
+    red: '#39c723'
+    green: '#5ad2e2'
+    yellow: '#a4e6ef'
+    blue: '#f8bfd5'
+    magenta: '#f18c7e'
+    cyan: '#f6b1cc'
+    white: '#f9f6f7'

--- a/standard/previews/base4tone-classic-d-dark.yaml.svg
+++ b/standard/previews/base4tone-classic-d-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#21211c" class="Dynamic" rx="5"/><text x="15" y="15" fill="#a2a090" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#cfb617" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#049582" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#a2a090" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#a2a090" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#a2a090" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#a2a090" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#21211c" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#049582" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#da6b2b" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#ee9968" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#cfb617" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#82c115" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#e6854d" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#eeede8" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#a2a090" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#0d0c07" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#1cc4ae" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#f0a57a" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#f5c1a3" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#f6edb1" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#95dc18" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#f2e58c" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f9f8f6" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#a2a090" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#82c115" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#da6b2b" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#ee9968" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#da6b2b" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#da6b2b" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base4tone-classic-i-dark.yaml.svg
+++ b/standard/previews/base4tone-classic-i-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#1d201d" class="Dynamic" rx="5"/><text x="15" y="15" fill="#949e95" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#24cc38" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#5c6feb" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#949e95" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#949e95" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#949e95" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#949e95" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1d201d" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#5c6feb" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#91a404" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#c5dc18" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#24cc38" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#23b4c7" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#adc115" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#e8ede9" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#949e95" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#080d08" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#929ff7" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#cee61a" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#e6f28c" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#b5f2bc" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#3ccadd" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#97eda1" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f6f9f6" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#949e95" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#23b4c7" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#91a404" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#c5dc18" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#91a404" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#91a404" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base4tone-classic-p-dark.yaml.svg
+++ b/standard/previews/base4tone-classic-p-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#1c1d21" class="Dynamic" rx="5"/><text x="15" y="15" fill="#9092a2" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#929ff7" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#c039d5" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#9092a2" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#9092a2" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#9092a2" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#9092a2" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1c1d21" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#c039d5" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#1398aa" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#3ccadd" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#929ff7" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#a57af0" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#23b4c7" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#e8e8ee" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#9092a2" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#07080d" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#db75eb" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#5ad2e2" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#a4e6ef" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#d0d5fb" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#b792f6" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#c6cdfb" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f6f6f9" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#9092a2" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#a57af0" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#1398aa" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#3ccadd" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#1398aa" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#1398aa" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base4tone-classic-s-dark.yaml.svg
+++ b/standard/previews/base4tone-classic-s-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#1f1d20" class="Dynamic" rx="5"/><text x="15" y="15" fill="#9a949e" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#c27eed" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#d64f3d" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#9a949e" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#9a949e" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#9a949e" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#9a949e" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1f1d20" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#d64f3d" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#7e70e6" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#aba1f7" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#c27eed" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#e963b8" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#9488f2" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#ebe8ed" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#9a949e" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#0b070d" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#eb8275" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#b7aff8" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#d1cbfb" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#e6c8f9" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#f17ec7" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#e0baf7" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f8f6f9" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#9a949e" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#e963b8" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#7e70e6" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#aba1f7" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#7e70e6" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#7e70e6" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base4tone-classic-w-dark.yaml.svg
+++ b/standard/previews/base4tone-classic-w-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#201d1e" class="Dynamic" rx="5"/><text x="15" y="15" fill="#9e9498" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#eb75a2" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#b87305" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#9e9498" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#9e9498" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#9e9498" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#9e9498" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#201d1e" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#b87305" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#ca45de" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#e17ef1" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#eb75a2" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#e97263" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#d763e9" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#ede8ea" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#9e9498" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#0d080a" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#e6971a" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#e691f3" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#edb1f6" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#f8bfd5" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#f18c7e" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#f6b1cc" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f9f6f7" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#9e9498" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#e97263" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#ca45de" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#e17ef1" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#ca45de" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#ca45de" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base4tone-modern-n-dark.yaml.svg
+++ b/standard/previews/base4tone-modern-n-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#1a2023" class="Dynamic" rx="5"/><text x="15" y="15" fill="#8a9da8" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#47b5f5" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#d53975" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#8a9da8" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#8a9da8" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#8a9da8" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#8a9da8" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1a2023" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#d53975" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#a48f04" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#dcc218" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#47b5f5" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#8493f6" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#c1aa15" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#e8ebee" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#8a9da8" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#070b0d" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#eb75a2" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#e6ca1a" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#f2e58c" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#bbe4fb" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#a0acf8" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#b1e0fb" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f6f8f9" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#8a9da8" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#8493f6" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#a48f04" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#dcc218" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#a48f04" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#a48f04" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/base4tone-modern-w-dark.yaml.svg
+++ b/standard/previews/base4tone-modern-w-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#201d1e" class="Dynamic" rx="5"/><text x="15" y="15" fill="#9e9498" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#eb75a2" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#21a00d" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#9e9498" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#9e9498" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#9e9498" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#9e9498" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#201d1e" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#21a00d" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#1398aa" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#3ccadd" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#eb75a2" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#e97263" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#23b4c7" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#ede8ea" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#9e9498" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#0d080a" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#39c723" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#5ad2e2" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#a4e6ef" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#f8bfd5" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#f18c7e" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#f6b1cc" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f9f6f7" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#9e9498" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#e97263" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#1398aa" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#3ccadd" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#1398aa" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#1398aa" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
# Pull Request for Base4Tone themes

## Base4Tone

## This has been tested
I have run the python script

## Notes
These are some of the dark themes of [Base4Tone](https://atelierbram.github.io/syntax-highlighting/base4tone/). If people would like to use some of the other dark - or the light variations of these themes they can find them at [github.com/atelierbram/Base4Tone-warp](https://github.com/atelierbram/Base4Tone-warp).
