### PR TITLE
Add Selenized theme

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -94,6 +94,10 @@
 |**[Popos Light](popos_light.yaml)**:|<img src='previews/popos_light.yaml.svg' width='300'>|
 |**[Remedy Dark](remedy_dark.yaml)**:|<img src='previews/remedy_dark.yaml.svg' width='300'>|
 |**[Seashells](seashells.yaml)**:|<img src='previews/seashells.yaml.svg' width='300'>|
+|**[Selenized Black](selenized_black.yaml)**:|<img src='previews/selenized_black.yaml.svg' width='300'>|
+|**[Selenized Dark](selenized_dark.yaml)**:|<img src='previews/selenized_dark.yaml.svg' width='300'>|
+|**[Selenized Light](selenized_light.yaml)**:|<img src='previews/selenized_light.yaml.svg' width='300'>|
+|**[Selenized White](selenized_white.yaml)**:|<img src='previews/selenized_white.yaml.svg' width='300'>|
 |**[Shades Of Purple](shades_of_purple.yaml)**:|<img src='previews/shades_of_purple.yaml.svg' width='300'>|
 |**[Shades Of Purple Super Dark](shades_of_purple_super_dark.yaml)**:|<img src='previews/shades_of_purple_super_dark.yaml.svg' width='300'>|
 |**[Simply Dark](simply_dark.yaml)**:|<img src='previews/simply_dark.yaml.svg' width='300'>|

--- a/standard/previews/selenized_black.yaml.svg
+++ b/standard/previews/selenized_black.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#181818" class="Dynamic" rx="5"/><text x="15" y="15" fill="#b9b9b9" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#368aeb" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#ed4a46" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#b9b9b9" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#b9b9b9" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#b9b9b9" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#b9b9b9" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#252525" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#ed4a46" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#70b433" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#dbb31d" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#368aeb" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#eb6eb7" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#3fc5b7" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#777777" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#b9b9b9" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#3b3b3b" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ff5e56" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#83c746" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#efc541" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#4f9cfe" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#ff81ca" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#56d8c9" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#dedede" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#b9b9b9" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#eb6eb7" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#70b433" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#dbb31d" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#70b433" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#368aeb" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/selenized_dark.yaml.svg
+++ b/standard/previews/selenized_dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#103c48" class="Dynamic" rx="5"/><text x="15" y="15" fill="#adbcbc" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#4695f7" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#fa5750" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#adbcbc" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#adbcbc" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#adbcbc" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#adbcbc" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#184956" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#fa5750" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#75b938" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#dbb32d" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#4695f7" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#f275be" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#41c7b9" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#72898f" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#adbcbc" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#2d5b69" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ff665c" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#84c747" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#ebc13d" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#58a3ff" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#ff84cd" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#53d6c7" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#cad8d9" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#adbcbc" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#f275be" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#75b938" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#dbb32d" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#75b938" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#4695f7" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/selenized_light.yaml.svg
+++ b/standard/previews/selenized_light.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#fbf3db" class="Dynamic" rx="5"/><text x="15" y="15" fill="#53676d" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#0072d4" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#d2212d" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#53676d" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#53676d" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#53676d" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#53676d" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#ece3cc" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#d2212d" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#489100" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#ad8900" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#0072d4" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#ca4898" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#009c8f" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#909995" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#53676d" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#d5cdb6" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#cc1729" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#428b00" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#a78300" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#006dce" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#c44392" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#00978a" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#3a4d53" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#53676d" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#ca4898" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#489100" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#ad8900" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#489100" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#0072d4" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/selenized_white.yaml.svg
+++ b/standard/previews/selenized_white.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#ffffff" class="Dynamic" rx="5"/><text x="15" y="15" fill="#474747" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#0064e4" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#d6000c" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#474747" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#474747" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#474747" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#474747" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#ebebeb" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#d6000c" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#1d9700" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#c49700" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#0064e4" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#dd0f9d" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#00ad9c" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#878787" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#474747" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#cdcdcd" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#bf0000" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#008400" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#af8500" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#0054cf" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#c7008b" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#009a8a" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#282828" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#474747" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#dd0f9d" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#1d9700" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#c49700" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#1d9700" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#0064e4" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/selenized_black.yaml
+++ b/standard/selenized_black.yaml
@@ -1,0 +1,23 @@
+accent: "#368aeb"
+background: "#181818"
+details: darker
+foreground: "#b9b9b9"
+terminal_colors:
+  bright:
+    black: "#3b3b3b"
+    blue: "#4f9cfe"
+    cyan: "#56d8c9"
+    green: "#83c746"
+    magenta: "#ff81ca"
+    red: "#ff5e56"
+    white: "#dedede"
+    yellow: "#efc541"
+  normal:
+    black: "#252525"
+    blue: "#368aeb"
+    cyan: "#3fc5b7"
+    green: "#70b433"
+    magenta: "#eb6eb7"
+    red: "#ed4a46"
+    white: "#777777"
+    yellow: "#dbb31d"

--- a/standard/selenized_dark.yaml
+++ b/standard/selenized_dark.yaml
@@ -1,0 +1,23 @@
+accent: "#4695f7"
+background: "#103c48"
+details: darker
+foreground: "#adbcbc"
+terminal_colors:
+  bright:
+    black: "#2d5b69"
+    blue: "#58a3ff"
+    cyan: "#53d6c7"
+    green: "#84c747"
+    magenta: "#ff84cd"
+    red: "#ff665c"
+    white: "#cad8d9"
+    yellow: "#ebc13d"
+  normal:
+    black: "#184956"
+    blue: "#4695f7"
+    cyan: "#41c7b9"
+    green: "#75b938"
+    magenta: "#f275be"
+    red: "#fa5750"
+    white: "#72898f"
+    yellow: "#dbb32d"

--- a/standard/selenized_light.yaml
+++ b/standard/selenized_light.yaml
@@ -1,0 +1,23 @@
+accent: "#0072d4"
+background: "#fbf3db"
+details: lighter
+foreground: "#53676d"
+terminal_colors:
+  bright:
+    black: "#d5cdb6"
+    blue: "#006dce"
+    cyan: "#00978a"
+    green: "#428b00"
+    magenta: "#c44392"
+    red: "#cc1729"
+    white: "#3a4d53"
+    yellow: "#a78300"
+  normal:
+    black: "#ece3cc"
+    blue: "#0072d4"
+    cyan: "#009c8f"
+    green: "#489100"
+    magenta: "#ca4898"
+    red: "#d2212d"
+    white: "#909995"
+    yellow: "#ad8900"

--- a/standard/selenized_white.yaml
+++ b/standard/selenized_white.yaml
@@ -1,0 +1,23 @@
+accent: "#0064e4"
+background: "#ffffff"
+details: lighter
+foreground: "#474747"
+terminal_colors:
+  bright:
+    black: "#cdcdcd"
+    blue: "#0054cf"
+    cyan: "#009a8a"
+    green: "#008400"
+    magenta: "#c7008b"
+    red: "#bf0000"
+    white: "#282828"
+    yellow: "#af8500"
+  normal:
+    black: "#ebebeb"
+    blue: "#0064e4"
+    cyan: "#00ad9c"
+    green: "#1d9700"
+    magenta: "#dd0f9d"
+    red: "#d6000c"
+    white: "#878787"
+    yellow: "#c49700"


### PR DESCRIPTION
https://github.com/jan-warchol/selenized/tree/master

# Selenized Themes

## Name of theme

Selenized Dark
Selenized Light
Selenized Black
Selenized White

## How Has This Been Tested?

Tested using python script: `python3 ./scripts/gen_theme_previews.py <folder-name-eg-standard>`

## Notes

Selenized is a colour palette based on Ethan Shoonover's Solarized with adjusted hues and lightness to decrease ambiguity and ensure readability in all conditions. For full details see the project page at https://github.com/jan-warchol/selenized/tree/master.

**Selenized Light/Dark** — Like Solarized, but better. Dark teal and warm sepia complement each other nicely.
**Selenized White/Black** — Old school look with a little more contrast for high contrast situations (e.g. working outdoors)
