### PR TITLE
feat: add Galaxy Theme with iTerm2 Color Compatibility

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -40,6 +40,7 @@
 |**[Faithful Argonaut](faithful_argonaut.yaml)**:|<img src='previews/faithful_argonaut.yaml.svg' width='300'>|
 |**[Falcon](falcon.yaml)**:|<img src='previews/falcon.yaml.svg' width='300'>|
 |**[Flat Remix](flat_remix.yaml)**:|<img src='previews/flat_remix.yaml.svg' width='300'>|
+|**[Galaxy Iterm2 Compatiable](galaxy_iterm2_compatiable.yaml)**:|<img src='previews/galaxy_iterm2_compatiable.yaml.svg' width='300'>|
 |**[Github Dark](github_dark.yaml)**:|<img src='previews/github_dark.yaml.svg' width='300'>|
 |**[Github Dark Dimmed](github_dark_dimmed.yaml)**:|<img src='previews/github_dark_dimmed.yaml.svg' width='300'>|
 |**[Github Light](github_light.yaml)**:|<img src='previews/github_light.yaml.svg' width='300'>|

--- a/standard/galaxy_iterm2_compatiable.yaml
+++ b/standard/galaxy_iterm2_compatiable.yaml
@@ -1,0 +1,25 @@
+name: Galaxy
+accent: "#5698f6"
+background: "#273747"
+foreground: "#ffffff"
+details: darker
+terminal_colors:
+  normal:
+    black: "#000000"
+    red: "#f9555f"
+    green: "#20b089"
+    yellow: "#fef063"
+    blue: "#5698f6"
+    magenta: "#934d93"
+    cyan: "#1f9ee7"
+    white: "#bbbbbb"
+  bright:
+    black: "#555555"
+    red: "#fa817d"
+    green: "#34bb1e"
+    yellow: "#ffff54"
+    blue: "#589df6"
+    magenta: "#e75699"
+    cyan: "#3979bc"
+    white: "#ffffff"
+cursor: "#bbbbbb"

--- a/standard/previews/galaxy_iterm2_compatiable.yaml.svg
+++ b/standard/previews/galaxy_iterm2_compatiable.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#273747" class="Dynamic" rx="5"/><text x="15" y="15" fill="#ffffff" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#5698f6" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#f9555f" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#ffffff" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#ffffff" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#ffffff" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#ffffff" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#000000" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#f9555f" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#20b089" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#fef063" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#5698f6" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#934d93" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#1f9ee7" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#bbbbbb" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#ffffff" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#555555" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#fa817d" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#34bb1e" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#ffff54" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#589df6" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#e75699" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#3979bc" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#ffffff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#ffffff" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#934d93" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#20b089" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#fef063" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#20b089" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#5698f6" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
## Discord username (optional)
N/A

## Name of theme
Galaxy (iTerm2 Compatible)

## How Has This Been Tested?
- Verified with `python3 ./scripts/gen_theme_previews.py standard`
- Tested color compatibility across Warp and iTerm2
- Validated prompt colors match between terminals

## Notes
This theme addresses the color compatibility issue reported in [warpdotdev/Warp#3951](https://github.com/warpdotdev/Warp/issues/3951) where prompt colors differ between Warp and iTerm2. The theme has been specifically calibrated to ensure consistent color rendering across both terminals, particularly for:

- Path and prompt colors
- Terminal color palette
- Accent colors

The theme maintains Galaxy's signature look while ensuring color consistency between Warp and iTerm2 environments.