### PR TITLE
Add C64 theme on standard folder

### DIFF
--- a/standard/C64.yaml
+++ b/standard/C64.yaml
@@ -1,0 +1,23 @@
+accent: "#00c2ff"
+background: "#27188e"
+foreground: "#ddd2ff"
+details: "darker"
+terminal_colors:
+  normal:
+    black: "#000000"
+    red: "#ac665c"
+    green: "#57992e"
+    yellow: "#7e8a13"
+    blue: "#766ad5"
+    magenta: "#9c5ac0"
+    cyan: "#468e97"
+    white: "#e1e1e1"
+  bright:
+    black: "#000000"
+    red: "#ffcfc6"
+    green: "#c1fe9d"
+    yellow: "#e5f088"
+    blue: "#6276cb"
+    magenta: "#ffc4ff"
+    cyan: "#b2f4fc"
+    white: "#e1e1e1"

--- a/standard/README.md
+++ b/standard/README.md
@@ -1,5 +1,6 @@
 |Theme name | Preview|
 | --- | --- |
+|**[C64](C64.yaml)**:|<img src='previews/C64.yaml.svg' width='300'>|
 |**[Afterglow](afterglow.yaml)**:|<img src='previews/afterglow.yaml.svg' width='300'>|
 |**[Apple Dark](apple_dark.yaml)**:|<img src='previews/apple_dark.yaml.svg' width='300'>|
 |**[Apple Light](apple_light.yaml)**:|<img src='previews/apple_light.yaml.svg' width='300'>|

--- a/standard/previews/C64.yaml.svg
+++ b/standard/previews/C64.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#27188e" class="Dynamic" rx="5"/><text x="15" y="15" fill="#ddd2ff" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#766ad5" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#ac665c" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#ddd2ff" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#ddd2ff" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#ddd2ff" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#ddd2ff" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#000000" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#ac665c" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#57992e" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#7e8a13" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#766ad5" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#9c5ac0" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#468e97" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#e1e1e1" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#ddd2ff" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#000000" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ffcfc6" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#c1fe9d" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#e5f088" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#6276cb" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#ffc4ff" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#b2f4fc" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#e1e1e1" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#ddd2ff" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#9c5ac0" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#57992e" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#7e8a13" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#57992e" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#00c2ff" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
# Pull Request Template
![image](https://github.com/user-attachments/assets/36d3741d-d7fd-49cc-9735-db6e91ca7a49)
![image](https://github.com/user-attachments/assets/f1307b9d-b4c4-4045-a408-de063d60438f)
![image](https://github.com/user-attachments/assets/0d7e001a-29ad-469a-8e11-a03c42a793f7)

## Name of theme

C64, Commodore 64, C64 Basic.

## How Has This Been Tested?

```python3 ./scripts/gen_theme_previews.py <folder-name-eg-standard>```

## Notes
For a better experience, I recommend to add a custom font. You can find it here: https://style64.org/c64-truetype
