### PR TITLE
Add Kiro Dark theme

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -57,6 +57,7 @@
 |**[Iterm](iterm.yaml)**:|<img src='previews/iterm.yaml.svg' width='300'>|
 |**[Jellybeans](jellybeans.yaml)**:|<img src='previews/jellybeans.yaml.svg' width='300'>|
 |**[Kanagawa](kanagawa.yaml)**:|<img src='previews/kanagawa.yaml.svg' width='300'>|
+|**[Kiro-dark](kiro-dark.yaml)**:|<img src='previews/kiro-dark.yaml.svg' width='300'>|
 |**[Konsole Linux](konsole_linux.yaml)**:|<img src='previews/konsole_linux.yaml.svg' width='300'>|
 |**[Laser](laser.yaml)**:|<img src='previews/laser.yaml.svg' width='300'>|
 |**[Light-pinkish](light-pinkish.yaml)**:|<img src='previews/light-pinkish.yaml.svg' width='300'>|

--- a/standard/kiro-dark.yaml
+++ b/standard/kiro-dark.yaml
@@ -1,0 +1,23 @@
+accent: "#b080ff"
+background: "#19161d"
+details: darker
+foreground: "#cccccc"
+terminal_colors:
+  bright:
+    black: "#555555"
+    blue: "#8dc8fb"
+    cyan: "#80f4ff"
+    green: "#80ffb5"
+    magenta: "#8e47ff"
+    red: "#ff8080"
+    white: "#e5e5e5"
+    yellow: "#fff2b3"
+  normal:
+    black: "#000000"
+    blue: "#8dc8fb"
+    cyan: "#80f4ff"
+    green: "#80ffb5"
+    magenta: "#8e47ff"
+    red: "#ff8080"
+    white: "#e5e5e5"
+    yellow: "#fff2b3"

--- a/standard/previews/kiro-dark.yaml.svg
+++ b/standard/previews/kiro-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#19161d" class="Dynamic" rx="5"/><text x="15" y="15" fill="#cccccc" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#8dc8fb" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#ff8080" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#cccccc" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#cccccc" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#cccccc" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#cccccc" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#000000" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#ff8080" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#80ffb5" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#fff2b3" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#8dc8fb" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#8e47ff" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#80f4ff" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#e5e5e5" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#cccccc" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#555555" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ff8080" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#80ffb5" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#fff2b3" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#8dc8fb" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#8e47ff" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#80f4ff" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#e5e5e5" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#cccccc" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#8e47ff" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#80ffb5" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#fff2b3" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#80ffb5" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#b080ff" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
# Add Kiro Dark Theme

## Description
- Added kiro-dark.yaml theme with purple/violet color scheme
- Features dark background (#19161d) with accent color (#b080ff)
- Includes warm color palette with soft pastels
- Generated preview image and updated README documentation
- Follows standard theme format for Warp themes repository

## Discord username
rahthakor

## Name of theme
Kiro Dark

## How Has This Been Tested?
Yes, I have run the python script:
```bash
python3 ./scripts/gen_theme_previews.py standard
```

The script executed successfully and generated:
- `standard/previews/kiro-dark.yaml.svg` - Preview image for the theme
- Updated `standard/README.md` with the new theme entry

The theme has also been tested in Warp terminal to verify:
- Colors display correctly
- Background, foreground, and accent colors render as expected
- ANSI colors work properly in various terminal applications
- Theme loads without errors

## Theme Details
- **Background**: Deep purple `#19161d`
- **Accent**: Light purple `#b080ff`
- **Foreground**: Light gray `#cccccc`
- **Style**: Dark theme with warm pastel color palette
- **Color Scheme**: Purple/violet themed with complementary colors

## Notes
This theme does not include any custom background images. It follows the standard YAML format and includes only color definitions as per the repository guidelines.

The theme provides a modern, dark aesthetic with a purple/violet color scheme that's easy on the eyes while maintaining good contrast and readability.