### PR TITLE
Add Zed One Dark and Light themes

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -124,5 +124,7 @@
 |**[Vuesion](vuesion.yaml)**:|<img src='previews/vuesion.yaml.svg' width='300'>|
 |**[Wombat](wombat.yaml)**:|<img src='previews/wombat.yaml.svg' width='300'>|
 |**[Xterm](xterm.yaml)**:|<img src='previews/xterm.yaml.svg' width='300'>|
+|**[Zed-one-dark](zed-one-dark.yaml)**:|<img src='previews/zed-one-dark.yaml.svg' width='300'>|
+|**[Zed-one-light](zed-one-light.yaml)**:|<img src='previews/zed-one-light.yaml.svg' width='300'>|
 |**[Zenbones Dark](zenbones_dark.yaml)**:|<img src='previews/zenbones_dark.yaml.svg' width='300'>|
 |**[Zenbones Light](zenbones_light.yaml)**:|<img src='previews/zenbones_light.yaml.svg' width='300'>|

--- a/standard/previews/zed_one_dark.yaml.svg
+++ b/standard/previews/zed_one_dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#282c33" class="Dynamic" rx="5"/><text x="15" y="15" fill="#dce0e5" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#61afef" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#e06c75" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#dce0e5" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#dce0e5" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#dce0e5" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#dce0e5" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#5c6370" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#e06c75" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#98c379" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#e5c07b" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#61afef" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#c678dd" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#56b6c2" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#abb2bf" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#dce0e5" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#7c8696" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#e6878c" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#b5d196" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#f0d89a" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#8bb8f0" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#d16b61" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#7ec4d0" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f0f3f8" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#dce0e5" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#c678dd" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#98c379" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#e5c07b" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#98c379" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#74ade8" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/zed_one_light.yaml.svg
+++ b/standard/previews/zed_one_light.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#fafafa" class="Dynamic" rx="5"/><text x="15" y="15" fill="#242529" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#5c78e2" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#d36151" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#242529" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#242529" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#242529" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#242529" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#242529" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#d36151" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#669f59" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#a48819" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#5c78e2" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#984ea5" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#3a82b7" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#fafafa" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#242529" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#242529" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#d36151" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#669f59" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#dec184" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#5c78e2" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#984ea5" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#3a82b7" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#fafafa" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#242529" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#984ea5" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#669f59" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#a48819" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#669f59" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#5c78e2" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/zed_one_dark.yaml
+++ b/standard/zed_one_dark.yaml
@@ -1,0 +1,23 @@
+accent: "#74ade8"
+background: '#282c33'
+foreground: '#dce0e5'
+details: darker
+terminal_colors:
+  bright:
+    black: '#7c8696'
+    blue: '#8bb8f0'
+    cyan: '#7ec4d0'
+    green: '#b5d196'
+    magenta: '#d16b61'
+    red: '#e6878c'
+    white: '#f0f3f8'
+    yellow: '#f0d89a'
+  normal:
+    black: '#5c6370'
+    blue: '#61afef'
+    cyan: '#56b6c2'
+    green: '#98c379'
+    magenta: '#c678dd'
+    red: '#e06c75'
+    white: '#abb2bf'
+    yellow: '#e5c07b'

--- a/standard/zed_one_light.yaml
+++ b/standard/zed_one_light.yaml
@@ -1,0 +1,23 @@
+accent: "#5c78e2"
+background: '#fafafa'
+foreground: '#242529'
+details: lighter
+terminal_colors:
+  bright:
+    black: '#242529'
+    blue: '#5c78e2'
+    cyan: '#3a82b7'
+    green: '#669f59'
+    magenta: '#984ea5'
+    red: '#d36151'
+    white: '#fafafa'
+    yellow: '#dec184'
+  normal:
+    black: '#242529'
+    blue: '#5c78e2'
+    cyan: '#3a82b7'
+    green: '#669f59'
+    magenta: '#984ea5'
+    red: '#d36151'
+    white: '#fafafa'
+    yellow: '#a48819'


### PR DESCRIPTION
## Name of theme

Zed One Dark and Zed One Light

## How Has This Been Tested?

✅ Generated preview images using `python3 ./scripts/gen_theme_previews.py standard`

## Contributing Guidelines Checklist

- [x] Forked the project
- [x] Created feature branch with `theme/` prefix format
- [x] All colors in hex format starting with `#`
- [x] No custom background images included
- [x] Files added to `standard/` directory
- [x] Preview images generated and committed
- [x] Regenerated thumbnails using required script
- [x] Files use snake_case naming (following existing repo patterns)

## ⚠️ Documentation vs Schema Conflict

**Documentation states** ([Custom Themes docs](https://docs.warp.dev/features/themes/custom-themes#create-your-custom-theme-manually)):
> "A custom theme in Warp has the following `.yaml` structure:"
```yaml
name: Custom Theme # Name for the theme
cursor: '#95D886' # Input cursor color (optional; defaults to accent color if omitted)

However:

[ ] name field: Adding this produces error: "Property name is not allowed. (yaml-schema: warp-themes.json 513)"
[ ] cursor field: Adding this produces error: "Property cursor is not allowed. (yaml-schema: warp-themes.json 513)"

Existing themes confirmation: solarized_dark.yaml, solarized_light.yaml, and other standard themes omit both name and cursor fields.

Current approach: Followed existing theme structure and schema validation to ensure themes work properly. Please confirm if documentation needs updating or if there's a
different schema for contributed themes.