### PR TITLE
Fix the path to the Lumon background.

### DIFF
--- a/special_edition/lumon.yaml
+++ b/special_edition/lumon.yaml
@@ -2,7 +2,7 @@ background: "#05333F"
 accent: "#0DA6B0"
 foreground: "#A8E2E8"
 background_image:
-  path: lumon.jpg
+  path: special_edition/lumon.jpg
   opacity: 100
 details: darker
 terminal_colors:


### PR DESCRIPTION
This aligns with
https://docs.warp.dev/terminal/appearance/custom-themes#background-images-and-gradients , which indicates:
```
    the path is relative to ~/.warp/themes/
```

# Pull Request Template

## Discord username (optional)

n/a

## Name of theme

Lumon

## How Has This Been Tested?

Have you run the python script? `python3 ./scripts/gen_theme_previews.py <folder-name-eg-standard>`

Yes.

## Notes

We cannot accept pull request that include custom background images because:

- of licensing restrictions
- we are trying to keep the binary size of the repo as small as possible (just the yaml files)

If your theme has an intended custom background image, include a comment in the yaml with a link to where people should download it.
