### PR TITLE
Elementarish colors corrected

### DIFF
--- a/stradicat/README.md
+++ b/stradicat/README.md
@@ -1,0 +1,3 @@
+|Theme name | Preview|
+| --- | --- |
+|**[Elementarish](elementarish.yaml)**:|<img src='previews/elementarish.yaml.svg' width='300'>|

--- a/stradicat/elementarish.yaml
+++ b/stradicat/elementarish.yaml
@@ -1,17 +1,8 @@
-background: "#2b2b2b"
 accent: "#268bd2"
+background: "#2b2b2b"
 foreground: "#93A1A1"
 details: darker
 terminal_colors:
-  normal:
-    black: "#2b2b2b"
-    red: "#dc322f"
-    green: "#859900"
-    yellow: "#b58901"
-    blue: "#268bd2"
-    magenta: "#d33682"
-    cyan: "#2aa198"
-    white: "#eee8d5"
   bright:
     black: "#586e75"
     red: "#dc322f"
@@ -21,3 +12,12 @@ terminal_colors:
     magenta: "#d33682"
     cyan: "#2aa198"
     white: "#6c71c4"
+  normal:
+    black: "#073642"
+    red: "#dc322f"
+    green: "#859900"
+    yellow: "#b58901"
+    blue: "#268bd2"
+    magenta: "#d33682"
+    cyan: "#2aa198"
+    white: "#eee8d5"

--- a/stradicat/previews/elementarish.yaml.svg
+++ b/stradicat/previews/elementarish.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#2b2b2b" class="Dynamic" rx="5"/><text x="15" y="15" fill="#93A1A1" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#268bd2" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#dc322f" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#93A1A1" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#93A1A1" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#93A1A1" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#93A1A1" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#073642" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#dc322f" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#859900" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#b58901" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#268bd2" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#d33682" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#2aa198" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#eee8d5" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#93A1A1" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#586e75" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#dc322f" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#859900" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#b58901" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#268bd2" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#d33682" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#2aa198" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#6c71c4" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#93A1A1" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#d33682" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#859900" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#b58901" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#859900" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#268bd2" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
# Pull Request Template

## Discord username (optional)
indigocat#1478

## Name of theme

Elementarish

## How Has This Been Tested?

Have you run the python script? `python3 ./scripts/gen_theme_previews.py <folder-name-eg-standard>`
- Yes

## Notes

Based on the `elementaryOS` terminal color palette (which uses some `Tango` colors).
Matches the [Elementarish theme](https://github.com/stradicat/btop/blob/main/themes/elementarish.theme) on `btop` (also contributed by me)