### PR TITLE
Add Retro Terminal theme - classic green on black aesthetic

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -93,6 +93,7 @@
 |**[Popos Dark](popos_dark.yaml)**:|<img src='previews/popos_dark.yaml.svg' width='300'>|
 |**[Popos Light](popos_light.yaml)**:|<img src='previews/popos_light.yaml.svg' width='300'>|
 |**[Remedy Dark](remedy_dark.yaml)**:|<img src='previews/remedy_dark.yaml.svg' width='300'>|
+|**[Retro Terminal](retro_terminal.yaml)**:|<img src='previews/retro_terminal.yaml.svg' width='300'>|
 |**[Seashells](seashells.yaml)**:|<img src='previews/seashells.yaml.svg' width='300'>|
 |**[Shades Of Purple](shades_of_purple.yaml)**:|<img src='previews/shades_of_purple.yaml.svg' width='300'>|
 |**[Shades Of Purple Super Dark](shades_of_purple_super_dark.yaml)**:|<img src='previews/shades_of_purple_super_dark.yaml.svg' width='300'>|

--- a/standard/previews/retro_terminal.yaml.svg
+++ b/standard/previews/retro_terminal.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#000000" class="Dynamic" rx="5"/><text x="15" y="15" fill="#00ff00" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#00cc88" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#00dd00" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#00ff00" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#00ff00" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#00ff00" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#00ff00" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#002200" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#00dd00" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#00ff00" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#66dd00" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#00cc88" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#00dd66" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#00ccaa" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#88ff88" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#00ff00" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#003300" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#00ff00" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#00ff41" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#88ff00" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#00ffcc" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#00ff88" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#00ffff" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#ccffcc" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#00ff00" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#00dd66" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#00ff00" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#66dd00" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#00ff00" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#00ff00" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/retro_terminal.yaml
+++ b/standard/retro_terminal.yaml
@@ -1,0 +1,25 @@
+name: Retro Terminal
+accent: '#00ff00'
+cursor: '#00ff41'
+background: '#000000'
+foreground: '#00ff00'
+details: darker
+terminal_colors:
+  bright:
+    black: '#003300'
+    blue: '#00ffcc'
+    cyan: '#00ffff'
+    green: '#00ff41'
+    magenta: '#00ff88'
+    red: '#00ff00'
+    white: '#ccffcc'
+    yellow: '#88ff00'
+  normal:
+    black: '#002200'
+    blue: '#00cc88'
+    cyan: '#00ccaa'
+    green: '#00ff00'
+    magenta: '#00dd66'
+    red: '#00dd00'
+    white: '#88ff88'
+    yellow: '#66dd00'


### PR DESCRIPTION
## Discord username (optional)
N/A

## Name of theme
Retro Terminal

## How Has This Been Tested?
Yes, I have run the python script:
```bash
python3 ./scripts/gen_theme_previews.py standard
```

The script successfully generated the preview thumbnail (`retro_terminal_yaml.svg`) without errors. The theme has also been tested locally in Warp terminal to verify all colors are visible and maintain the intended retro aesthetic.

## Notes
This theme does not include any custom background images. It uses a pure black background (#000000) with phosphor green text to achieve the classic CRT monitor aesthetic.

The theme features:
- Classic green-on-black terminal color scheme
- All ANSI colors use green spectrum variations for monochrome phosphor display feel
- Optimized visibility with darker greens for "black" colors that remain distinguishable on the black background
- Inspired by vintage Unix terminals and retro computing aesthetics