### PR TITLE
Add Nights theme

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -74,6 +74,7 @@
 |**[Monokai Pro Spectrum](monokai_pro_spectrum.yml)**:|<img src='previews/monokai_pro_spectrum.yml.svg' width='300'>|
 |**[Night Owl](night_owl.yaml)**:|<img src='previews/night_owl.yaml.svg' width='300'>|
 |**[Nightfly](nightfly.yaml)**:|<img src='previews/nightfly.yaml.svg' width='300'>|
+|**[Nights](nights.yaml)**:|<img src='previews/nights.yaml.svg' width='300'>|
 |**[Nord](nord.yaml)**:|<img src='previews/nord.yaml.svg' width='300'>|
 |**[Oceanic Next](oceanic_next.yaml)**:|<img src='previews/oceanic_next.yaml.svg' width='300'>|
 |**[Omni](omni.yaml)**:|<img src='previews/omni.yaml.svg' width='300'>|

--- a/standard/nights.yaml
+++ b/standard/nights.yaml
@@ -1,0 +1,23 @@
+accent: "#4a8a9a"
+background: "#0a0e12"
+details: darker
+foreground: "#d0d0d0"
+terminal_colors:
+  bright:
+    black: "#505050"
+    blue: "#80a8d8"
+    cyan: "#80c8c8"
+    green: "#90d090"
+    magenta: "#c890c0"
+    red: "#d89090"
+    white: "#e0e0e0"
+    yellow: "#d8d080"
+  normal:
+    black: "#000000"
+    blue: "#6090c8"
+    cyan: "#60b0b0"
+    green: "#70b870"
+    magenta: "#b070b0"
+    red: "#c87070"
+    white: "#c0c0c0"
+    yellow: "#c8b860"

--- a/standard/previews/nights.yaml.svg
+++ b/standard/previews/nights.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#0a0e12" class="Dynamic" rx="5"/><text x="15" y="15" fill="#d0d0d0" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#6090c8" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#c87070" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#d0d0d0" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#d0d0d0" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#d0d0d0" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#d0d0d0" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#000000" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#c87070" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#70b870" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#c8b860" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#6090c8" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#b070b0" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#60b0b0" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#c0c0c0" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#d0d0d0" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#505050" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#d89090" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#90d090" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#d8d080" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#80a8d8" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#c890c0" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#80c8c8" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#e0e0e0" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#d0d0d0" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#b070b0" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#70b870" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#c8b860" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#70b870" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#4a8a9a" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
## Summary
- Adds **Nights**, a dark muted theme with soft pastel ANSI colors and a deep teal-tinted background
- Designed for comfortable late-night coding sessions
- Preview SVG and README update included

## Preview
![Nights theme preview](standard/previews/nights.yaml.svg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)