### PR TITLE
Add Zenburn Colorblind High Contrast theme

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -126,3 +126,4 @@
 |**[Xterm](xterm.yaml)**:|<img src='previews/xterm.yaml.svg' width='300'>|
 |**[Zenbones Dark](zenbones_dark.yaml)**:|<img src='previews/zenbones_dark.yaml.svg' width='300'>|
 |**[Zenbones Light](zenbones_light.yaml)**:|<img src='previews/zenbones_light.yaml.svg' width='300'>|
+|**[Zenburn Colorblind High Contrast](zenburn_colorblind_high_contrast.yaml)**:|<img src='previews/zenburn_colorblind_high_contrast.yaml.svg' width='300'>|

--- a/standard/previews/zenburn_colorblind_high_contrast.yaml.svg
+++ b/standard/previews/zenburn_colorblind_high_contrast.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#2d2d2d" class="Dynamic" rx="5"/><text x="15" y="15" fill="#eaeaea" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#4d93cc" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#f25555" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#eaeaea" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#eaeaea" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#eaeaea" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#eaeaea" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#2d2d2d" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#f25555" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#3eb63e" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#f4a733" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#4d93cc" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#c846c8" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#46b3b3" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#eaeaea" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#eaeaea" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#6a6a6a" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ff6f6f" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#5cd95c" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#ffbb55" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#70aae6" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#eb70eb" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#70e6e6" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#ffffff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#eaeaea" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#c846c8" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#3eb63e" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#f4a733" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#3eb63e" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#46a9ad" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/zenburn_colorblind_high_contrast.yaml
+++ b/standard/zenburn_colorblind_high_contrast.yaml
@@ -1,0 +1,25 @@
+name: Zenburn Colorblind High Contrast
+accent: '#46a9ad'
+cursor: '#47cc7c'
+background: '#2d2d2d'
+foreground: '#eaeaea'
+details: darker
+terminal_colors:
+  normal:
+    black: '#2d2d2d'
+    red: '#f25555'
+    green: '#3eb63e'
+    yellow: '#f4a733'
+    blue: '#4d93cc'
+    magenta: '#c846c8'
+    cyan: '#46b3b3'
+    white: '#eaeaea'
+  bright:
+    black: '#6a6a6a'
+    red: '#ff6f6f'
+    green: '#5cd95c'
+    yellow: '#ffbb55'
+    blue: '#70aae6'
+    magenta: '#eb70eb'
+    cyan: '#70e6e6'
+    white: '#ffffff'


### PR DESCRIPTION
# Pull Request Template

## Name of theme

Zenburn Colorblind High Contrast

## How Has This Been Tested?

Have you run the python script? `python3 ./scripts/gen_theme_previews.py <folder-name-eg-standard>`
yes i have

## Notes

We cannot accept pull request that include custom background images because:

- of licensing restrictions
- we are trying to keep the binary size of the repo as small as possible (just the yaml files)

If your theme has an intended custom background image, include a comment in the yaml with a link to where people should download it.
