### PR TITLE
Add Zenburn Colorblind theme

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -126,3 +126,4 @@
 |**[Xterm](xterm.yaml)**:|<img src='previews/xterm.yaml.svg' width='300'>|
 |**[Zenbones Dark](zenbones_dark.yaml)**:|<img src='previews/zenbones_dark.yaml.svg' width='300'>|
 |**[Zenbones Light](zenbones_light.yaml)**:|<img src='previews/zenbones_light.yaml.svg' width='300'>|
+|**[Zenburn Colorblind](zenburn_colorblind.yaml)**:|<img src='previews/zenburn_colorblind.yaml.svg' width='300'>|

--- a/standard/previews/zenburn_colorblind.yaml.svg
+++ b/standard/previews/zenburn_colorblind.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#3f3f3f" class="Dynamic" rx="5"/><text x="15" y="15" fill="#dcdccc" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#5d9bd5" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#e65c5c" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#dcdccc" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#dcdccc" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#dcdccc" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#dcdccc" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#3f3f3f" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#e65c5c" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#5cb85c" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#f0ad4e" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#5d9bd5" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#b85cb8" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#5cb8b8" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#dcdccc" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#dcdccc" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#709080" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ff7070" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#70d970" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#ffc870" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#70b3ff" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#d970d9" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#70e0e0" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#ffffff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#dcdccc" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#b85cb8" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#5cb85c" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#f0ad4e" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#5cb85c" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#8cd0d3" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/zenburn_colorblind.yaml
+++ b/standard/zenburn_colorblind.yaml
@@ -1,0 +1,25 @@
+name: Zenburn Colorblind
+accent: '#8cd0d3'
+cursor: '#8faf9f'
+background: '#3f3f3f'
+foreground: '#dcdccc'
+details: darker
+terminal_colors:
+  normal:
+    black: '#3f3f3f'
+    red: '#e65c5c'
+    green: '#5cb85c'
+    yellow: '#f0ad4e'
+    blue: '#5d9bd5'
+    magenta: '#b85cb8'
+    cyan: '#5cb8b8'
+    white: '#dcdccc'
+  bright:
+    black: '#709080'
+    red: '#ff7070'
+    green: '#70d970'
+    yellow: '#ffc870'
+    blue: '#70b3ff'
+    magenta: '#d970d9'
+    cyan: '#70e0e0'
+    white: '#ffffff'


### PR DESCRIPTION
# Pull Request Template

## Name of theme

Zenburn Colorblind

## How Has This Been Tested?

Have you run the python script? `python3 ./scripts/gen_theme_previews.py <folder-name-eg-standard>`
Yes i have

## Notes

We cannot accept pull request that include custom background images because:

- of licensing restrictions
- we are trying to keep the binary size of the repo as small as possible (just the yaml files)

If your theme has an intended custom background image, include a comment in the yaml with a link to where people should download it.
