### PR TITLE
Add 15 SeedFlip themes

### DIFF
--- a/standard/seedflip_abyss.yaml
+++ b/standard/seedflip_abyss.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Abyss
+# Premium darkness
+# https://seedflip.co
+accent: "#6E56CF"
+background: "#050510"
+foreground: "#E0E0F0"
+details: darker
+terminal_colors:
+  normal:
+    black: "#030308"
+    red: "#d26060"
+    green: "#60d286"
+    yellow: "#d2bf60"
+    blue: "#6090d2"
+    magenta: "#d260d2"
+    cyan: "#60d2d2"
+    white: "#f1f1f8"
+  bright:
+    black: "#17174a"
+    red: "#e39c9c"
+    green: "#9ce3b3"
+    yellow: "#e3d79c"
+    blue: "#9cb9e3"
+    magenta: "#e39ce3"
+    cyan: "#9ce3e3"
+    white: "#FFFFFF"

--- a/standard/seedflip_amethyst.yaml
+++ b/standard/seedflip_amethyst.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Amethyst
+# Royal confidence in quiet rooms
+# https://seedflip.co
+accent: "#635BFF"
+background: "#F8F7F6"
+foreground: "#1A0A2E"
+details: lighter
+terminal_colors:
+  normal:
+    black: "#d7d1cb"
+    red: "#bd0f0f"
+    green: "#0fbd49"
+    yellow: "#bda00f"
+    blue: "#0f58bd"
+    magenta: "#bd0fbd"
+    cyan: "#0fbdbd"
+    white: "#0e0519"
+  bright:
+    black: "#b5aba0"
+    red: "#ee2b2b"
+    green: "#2bee6c"
+    yellow: "#eecd2b"
+    blue: "#2b7cee"
+    magenta: "#ee2bee"
+    cyan: "#2beeee"
+    white: "#1A0A2E"

--- a/standard/seedflip_canopy.yaml
+++ b/standard/seedflip_canopy.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Canopy
+# Energy from the roots.
+# https://seedflip.co
+accent: "#3ECF8E"
+background: "#0F1714"
+foreground: "#EDEDED"
+details: darker
+terminal_colors:
+  normal:
+    black: "#0b110f"
+    red: "#d65c5c"
+    green: "#5cd685"
+    yellow: "#d6c25c"
+    blue: "#5c8fd6"
+    magenta: "#d65cd6"
+    cyan: "#5cd6d6"
+    white: "#fafafa"
+  bright:
+    black: "#2d453c"
+    red: "#e69999"
+    green: "#99e6b2"
+    yellow: "#e6d999"
+    blue: "#99b9e6"
+    magenta: "#e699e6"
+    cyan: "#99e6e6"
+    white: "#FFFFFF"

--- a/standard/seedflip_carbon.yaml
+++ b/standard/seedflip_carbon.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Carbon
+# Nothing wasted.
+# https://seedflip.co
+accent: "#000000"
+background: "#FAFAFA"
+foreground: "#000000"
+details: lighter
+terminal_colors:
+  normal:
+    black: "#d4d4d4"
+    red: "#993333"
+    green: "#339955"
+    yellow: "#998833"
+    blue: "#335d99"
+    magenta: "#993399"
+    cyan: "#339999"
+    white: "#000000"
+  bright:
+    black: "#aeaeae"
+    red: "#c65353"
+    green: "#53c679"
+    yellow: "#c6b353"
+    blue: "#5383c6"
+    magenta: "#c653c6"
+    cyan: "#53c6c6"
+    white: "#000000"

--- a/standard/seedflip_coral.yaml
+++ b/standard/seedflip_coral.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Coral
+# Tools that feel alive
+# https://seedflip.co
+accent: "#F24E1E"
+background: "#FFFFFF"
+foreground: "#1D1D1D"
+details: lighter
+terminal_colors:
+  normal:
+    black: "#d9d9d9"
+    red: "#bd0f0f"
+    green: "#0fbd49"
+    yellow: "#bda00f"
+    blue: "#0f58bd"
+    magenta: "#bd0fbd"
+    cyan: "#0fbdbd"
+    white: "#101010"
+  bright:
+    black: "#b3b3b3"
+    red: "#ee2b2b"
+    green: "#2bee6c"
+    yellow: "#eecd2b"
+    blue: "#2b7cee"
+    magenta: "#ee2bee"
+    cyan: "#2beeee"
+    white: "#1D1D1D"

--- a/standard/seedflip_ember.yaml
+++ b/standard/seedflip_ember.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Ember
+# Warmth that moves
+# https://seedflip.co
+accent: "#FF6B3D"
+background: "#0A0A0A"
+foreground: "#EDEDED"
+details: darker
+terminal_colors:
+  normal:
+    black: "#050505"
+    red: "#f04242"
+    green: "#42f07c"
+    yellow: "#f0d342"
+    blue: "#428bf0"
+    magenta: "#f042f0"
+    cyan: "#42f0f0"
+    white: "#fafafa"
+  bright:
+    black: "#303030"
+    red: "#f58989"
+    green: "#89f5ad"
+    yellow: "#f5e389"
+    blue: "#89b6f5"
+    magenta: "#f589f5"
+    cyan: "#89f5f5"
+    white: "#FFFFFF"

--- a/standard/seedflip_glacier.yaml
+++ b/standard/seedflip_glacier.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Glacier
+# Ice blue precision tools
+# https://seedflip.co
+accent: "#0EA5E9"
+background: "#F8FAFC"
+foreground: "#0F172A"
+details: lighter
+terminal_colors:
+  normal:
+    black: "#c2d4e5"
+    red: "#bd0f0f"
+    green: "#0fbd49"
+    yellow: "#bda00f"
+    blue: "#0f58bd"
+    magenta: "#bd0fbd"
+    cyan: "#0fbdbd"
+    white: "#080d17"
+  bright:
+    black: "#8dadce"
+    red: "#ee2b2b"
+    green: "#2bee6c"
+    yellow: "#eecd2b"
+    blue: "#2b7cee"
+    magenta: "#ee2bee"
+    cyan: "#2beeee"
+    white: "#0F172A"

--- a/standard/seedflip_inkwell.yaml
+++ b/standard/seedflip_inkwell.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Inkwell
+# Serif elegance meets dark mode
+# https://seedflip.co
+accent: "#C8B8A0"
+background: "#0A0A0A"
+foreground: "#E8E4DF"
+details: darker
+terminal_colors:
+  normal:
+    black: "#050505"
+    red: "#cc6666"
+    green: "#66cc88"
+    yellow: "#ccbb66"
+    blue: "#6690cc"
+    magenta: "#cc66cc"
+    cyan: "#66cccc"
+    white: "#f3f1ee"
+  bright:
+    black: "#303030"
+    red: "#df9f9f"
+    green: "#9fdfb5"
+    yellow: "#dfd49f"
+    blue: "#9fbadf"
+    magenta: "#df9fdf"
+    cyan: "#9fdfdf"
+    white: "#FFFFFF"

--- a/standard/seedflip_ivory.yaml
+++ b/standard/seedflip_ivory.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Ivory
+# Confidence in the details.
+# https://seedflip.co
+accent: "#635BFF"
+background: "#FFFFFF"
+foreground: "#0A2540"
+details: lighter
+terminal_colors:
+  normal:
+    black: "#d9d9d9"
+    red: "#bd0f0f"
+    green: "#0fbd49"
+    yellow: "#bda00f"
+    blue: "#0f58bd"
+    magenta: "#bd0fbd"
+    cyan: "#0fbdbd"
+    white: "#07182a"
+  bright:
+    black: "#b3b3b3"
+    red: "#ee2b2b"
+    green: "#2bee6c"
+    yellow: "#eecd2b"
+    blue: "#2b7cee"
+    magenta: "#ee2bee"
+    cyan: "#2beeee"
+    white: "#0A2540"

--- a/standard/seedflip_nightfall.yaml
+++ b/standard/seedflip_nightfall.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Nightfall
+# Precision after dark.
+# https://seedflip.co
+accent: "#818CF8"
+background: "#0A0A0F"
+foreground: "#E4E4E7"
+details: darker
+terminal_colors:
+  normal:
+    black: "#060609"
+    red: "#f04242"
+    green: "#42f07c"
+    yellow: "#f0d342"
+    blue: "#428bf0"
+    magenta: "#f042f0"
+    cyan: "#42f0f0"
+    white: "#f2f2f3"
+  bright:
+    black: "#29293d"
+    red: "#f58989"
+    green: "#89f5ad"
+    yellow: "#f5e389"
+    blue: "#89b6f5"
+    magenta: "#f589f5"
+    cyan: "#89f5f5"
+    white: "#FFFFFF"

--- a/standard/seedflip_phosphor.yaml
+++ b/standard/seedflip_phosphor.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Phosphor
+# Glow in the dark.
+# https://seedflip.co
+accent: "#00FF88"
+background: "#0C0C0C"
+foreground: "#B3FFB3"
+details: darker
+terminal_colors:
+  normal:
+    black: "#070707"
+    red: "#f04242"
+    green: "#42f07c"
+    yellow: "#f0d342"
+    blue: "#428bf0"
+    magenta: "#f042f0"
+    cyan: "#42f0f0"
+    white: "#cdffcd"
+  bright:
+    black: "#323232"
+    red: "#f58989"
+    green: "#89f5ad"
+    yellow: "#f5e389"
+    blue: "#89b6f5"
+    magenta: "#f589f5"
+    cyan: "#89f5f5"
+    white: "#FFFFFF"

--- a/standard/seedflip_pulse.yaml
+++ b/standard/seedflip_pulse.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Pulse
+# Sound you can see
+# https://seedflip.co
+accent: "#1DB954"
+background: "#121212"
+foreground: "#FFFFFF"
+details: darker
+terminal_colors:
+  normal:
+    black: "#0d0d0d"
+    red: "#e34f4f"
+    green: "#4fe380"
+    yellow: "#e3cb4f"
+    blue: "#4f8de3"
+    magenta: "#e34fe3"
+    cyan: "#4fe3e3"
+    white: "#ffffff"
+  bright:
+    black: "#383838"
+    red: "#ee9191"
+    green: "#91eeb0"
+    yellow: "#eede91"
+    blue: "#91b8ee"
+    magenta: "#ee91ee"
+    cyan: "#91eeee"
+    white: "#FFFFFF"

--- a/standard/seedflip_ultraviolet.yaml
+++ b/standard/seedflip_ultraviolet.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Ultraviolet
+# Deploy at midnight
+# https://seedflip.co
+accent: "#C77DFF"
+background: "#0B0014"
+foreground: "#E8E0F5"
+details: darker
+terminal_colors:
+  normal:
+    black: "#05000a"
+    red: "#f04242"
+    green: "#42f07c"
+    yellow: "#f0d342"
+    blue: "#428bf0"
+    magenta: "#f042f0"
+    cyan: "#42f0f0"
+    white: "#f6f3fb"
+  bright:
+    black: "#350061"
+    red: "#f58989"
+    green: "#89f5ad"
+    yellow: "#f5e389"
+    blue: "#89b6f5"
+    magenta: "#f589f5"
+    cyan: "#89f5f5"
+    white: "#FFFFFF"

--- a/standard/seedflip_voltage.yaml
+++ b/standard/seedflip_voltage.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Voltage
+# Neon hits midnight asphalt
+# https://seedflip.co
+accent: "#A6FF00"
+background: "#0A0A0A"
+foreground: "#F0F0F0"
+details: darker
+terminal_colors:
+  normal:
+    black: "#050505"
+    red: "#f04242"
+    green: "#42f07c"
+    yellow: "#f0d342"
+    blue: "#428bf0"
+    magenta: "#f042f0"
+    cyan: "#42f0f0"
+    white: "#fdfdfd"
+  bright:
+    black: "#303030"
+    red: "#f58989"
+    green: "#89f5ad"
+    yellow: "#f5e389"
+    blue: "#89b6f5"
+    magenta: "#f589f5"
+    cyan: "#89f5f5"
+    white: "#FFFFFF"

--- a/standard/seedflip_wavelength.yaml
+++ b/standard/seedflip_wavelength.yaml
@@ -1,0 +1,26 @@
+# SeedFlip — Wavelength
+# Deep space developer energy
+# https://seedflip.co
+accent: "#238636"
+background: "#0D1117"
+foreground: "#E6EDF3"
+details: darker
+terminal_colors:
+  normal:
+    black: "#090c10"
+    red: "#d55d5d"
+    green: "#5dd585"
+    yellow: "#d5c15d"
+    blue: "#5d8fd5"
+    magenta: "#d55dd5"
+    cyan: "#5dd5d5"
+    white: "#f7f9fb"
+  bright:
+    black: "#293548"
+    red: "#e59a9a"
+    green: "#9ae5b3"
+    yellow: "#e5d89a"
+    blue: "#9ab9e5"
+    magenta: "#e59ae5"
+    cyan: "#9ae5e5"
+    white: "#FFFFFF"


### PR DESCRIPTION
## Summary

15 curated design seeds from [SeedFlip](https://seedflip.co), a design system generator with 104 production-ready seeds.

**Dark themes (10):** Nightfall, Phosphor, Ember, Ultraviolet, Abyss, Wavelength, Inkwell, Voltage, Canopy, Pulse
**Light themes (5):** Ivory, Carbon, Coral, Glacier, Amethyst

Each theme's ANSI palette is algorithmically derived from the seed's accent color and background, with saturation matched to the seed's energy level.

Note: SVG previews not included as I don't have the preview generator dependencies set up. Happy to generate them if needed.