### PR TITLE
Add Pierre Dark and Pierre Light themes

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -88,6 +88,8 @@
 |**[Pencil Light](pencil_light.yaml)**:|<img src='previews/pencil_light.yaml.svg' width='300'>|
 |**[Penumbra Dark](penumbra_dark.yaml)**:|<img src='previews/penumbra_dark.yaml.svg' width='300'>|
 |**[Penumbra Light](penumbra_light.yaml)**:|<img src='previews/penumbra_light.yaml.svg' width='300'>|
+|**[Pierre Dark](pierre_dark.yaml)**:|<img src='previews/pierre_dark.yaml.svg' width='300'>|
+|**[Pierre Light](pierre_light.yaml)**:|<img src='previews/pierre_light.yaml.svg' width='300'>|
 |**[Plastic](plastic.yaml)**:|<img src='previews/plastic.yaml.svg' width='300'>|
 |**[Poimandres](poimandres.yaml)**:|<img src='previews/poimandres.yaml.svg' width='300'>|
 |**[Poimandres Alt](poimandres_alt.yaml)**:|<img src='previews/poimandres_alt.yaml.svg' width='300'>|
@@ -103,6 +105,9 @@
 |**[Snazzy Green](snazzy_green.yaml)**:|<img src='previews/snazzy_green.yaml.svg' width='300'>|
 |**[Snazzy Red](snazzy_red.yaml)**:|<img src='previews/snazzy_red.yaml.svg' width='300'>|
 |**[Soft One Dark](soft_one_dark.yaml)**:|<img src='previews/soft_one_dark.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Cream](soft_tactile_warp_cream.yaml)**:|<img src='previews/soft_tactile_warp_cream.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Dark](soft_tactile_warp_dark.yaml)**:|<img src='previews/soft_tactile_warp_dark.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Light](soft_tactile_warp_light.yaml)**:|<img src='previews/soft_tactile_warp_light.yaml.svg' width='300'>|
 |**[Solarized Dark](solarized_dark.yaml)**:|<img src='previews/solarized_dark.yaml.svg' width='300'>|
 |**[Solarized Light](solarized_light.yaml)**:|<img src='previews/solarized_light.yaml.svg' width='300'>|
 |**[Spaceduck](spaceduck.yaml)**:|<img src='previews/spaceduck.yaml.svg' width='300'>|

--- a/standard/pierre_dark.yaml
+++ b/standard/pierre_dark.yaml
@@ -1,0 +1,30 @@
+# Pierre Dark theme
+# Source: https://github.com/pierrecomputer/theme
+# Accent color for UI elements
+accent: "#009fff"
+# Terminal background color
+background: "#070707"
+# Whether the theme is lighter or darker.
+details: darker
+# The foreground color.
+foreground: "#fbfbfb"
+# Ansi escape colors.
+terminal_colors:
+  bright:
+    black: "#141415"
+    red: "#ff2e3f"
+    green: "#0dbe4e"
+    yellow: "#ffca00"
+    blue: "#009fff"
+    magenta: "#c635e4"
+    cyan: "#08c0ef"
+    white: "#c6c6c8"
+  normal:
+    black: "#141415"
+    red: "#ff2e3f"
+    green: "#0dbe4e"
+    yellow: "#ffca00"
+    blue: "#009fff"
+    magenta: "#c635e4"
+    cyan: "#08c0ef"
+    white: "#c6c6c8"

--- a/standard/pierre_light.yaml
+++ b/standard/pierre_light.yaml
@@ -1,0 +1,30 @@
+# Pierre Light theme
+# Source: https://github.com/pierrecomputer/theme
+# Accent color for UI elements
+accent: "#009fff"
+# Terminal background color
+background: "#ffffff"
+# Whether the theme is lighter or darker.
+details: lighter
+# The foreground color.
+foreground: "#070707"
+# Ansi escape colors.
+terminal_colors:
+  bright:
+    black: "#1F1F21"
+    red: "#ff2e3f"
+    green: "#0dbe4e"
+    yellow: "#ffca00"
+    blue: "#009fff"
+    magenta: "#c635e4"
+    cyan: "#08c0ef"
+    white: "#c6c6c8"
+  normal:
+    black: "#1F1F21"
+    red: "#ff2e3f"
+    green: "#0dbe4e"
+    yellow: "#ffca00"
+    blue: "#009fff"
+    magenta: "#c635e4"
+    cyan: "#08c0ef"
+    white: "#c6c6c8"

--- a/standard/previews/pierre_dark.yaml.svg
+++ b/standard/previews/pierre_dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#070707" class="Dynamic" rx="5"/><text x="15" y="15" fill="#fbfbfb" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#009fff" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#ff2e3f" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#fbfbfb" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#fbfbfb" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#fbfbfb" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#fbfbfb" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#141415" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#ff2e3f" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#0dbe4e" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#ffca00" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#009fff" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#c635e4" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#08c0ef" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#c6c6c8" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#fbfbfb" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#141415" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ff2e3f" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#0dbe4e" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#ffca00" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#009fff" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#c635e4" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#08c0ef" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#c6c6c8" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#fbfbfb" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#c635e4" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#0dbe4e" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#ffca00" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#0dbe4e" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#009fff" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/pierre_light.yaml.svg
+++ b/standard/previews/pierre_light.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#ffffff" class="Dynamic" rx="5"/><text x="15" y="15" fill="#070707" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#009fff" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#ff2e3f" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#070707" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#070707" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#070707" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#070707" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1F1F21" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#ff2e3f" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#0dbe4e" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#ffca00" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#009fff" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#c635e4" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#08c0ef" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#c6c6c8" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#070707" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#1F1F21" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ff2e3f" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#0dbe4e" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#ffca00" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#009fff" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#c635e4" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#08c0ef" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#c6c6c8" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#070707" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#c635e4" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#0dbe4e" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#ffca00" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#0dbe4e" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#009fff" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
## Summary

- Add **Pierre Dark** and **Pierre Light** themes to the standard themes collection
- Colors sourced from the [Pierre Theme](https://github.com/pierrecomputer/theme) for VS Code, built by [The Pierre Computer Company](https://pierre.computer)
- Theme previews generated with `gen_theme_previews.py`

## Preview

**Pierre Dark**
![Pierre Dark](standard/previews/pierre_dark.yaml.svg)

**Pierre Light**
![Pierre Light](standard/previews/pierre_light.yaml.svg)

## Test plan

- [x] YAML files follow the existing theme format
- [x] Preview SVGs generated successfully
- [x] README updated with new theme entries