### PR TITLE
Add Serendipity and Sequoia theme families

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -96,6 +96,15 @@
 |**[Remedy Dark](remedy_dark.yaml)**:|<img src='previews/remedy_dark.yaml.svg' width='300'>|
 |**[Seashells](seashells.yaml)**:|<img src='previews/seashells.yaml.svg' width='300'>|
 |**[Shades Of Purple](shades_of_purple.yaml)**:|<img src='previews/shades_of_purple.yaml.svg' width='300'>|
+|**[Sequoia Monochrome Dark](sequoia_monochrome_dark.yaml)**:|<img src='previews/sequoia_monochrome_dark.yaml.svg' width='300'>|
+|**[Sequoia Monochrome Light](sequoia_monochrome_light.yaml)**:|<img src='previews/sequoia_monochrome_light.yaml.svg' width='300'>|
+|**[Sequoia Moonlight Dark](sequoia_moonlight_dark.yaml)**:|<img src='previews/sequoia_moonlight_dark.yaml.svg' width='300'>|
+|**[Sequoia Moonlight Light](sequoia_moonlight_light.yaml)**:|<img src='previews/sequoia_moonlight_light.yaml.svg' width='300'>|
+|**[Sequoia Retro Dark](sequoia_retro_dark.yaml)**:|<img src='previews/sequoia_retro_dark.yaml.svg' width='300'>|
+|**[Sequoia Retro Light](sequoia_retro_light.yaml)**:|<img src='previews/sequoia_retro_light.yaml.svg' width='300'>|
+|**[Serendipity Midnight](serendipity_midnight.yaml)**:|<img src='previews/serendipity_midnight.yaml.svg' width='300'>|
+|**[Serendipity Morning](serendipity_morning.yaml)**:|<img src='previews/serendipity_morning.yaml.svg' width='300'>|
+|**[Serendipity Sunset](serendipity_sunset.yaml)**:|<img src='previews/serendipity_sunset.yaml.svg' width='300'>|
 |**[Shades Of Purple Super Dark](shades_of_purple_super_dark.yaml)**:|<img src='previews/shades_of_purple_super_dark.yaml.svg' width='300'>|
 |**[Simply Dark](simply_dark.yaml)**:|<img src='previews/simply_dark.yaml.svg' width='300'>|
 |**[Snazzy](snazzy.yaml)**:|<img src='previews/snazzy.yaml.svg' width='300'>|

--- a/standard/previews/sequoia_monochrome_dark.yaml.svg
+++ b/standard/previews/sequoia_monochrome_dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#0f1014" class="Dynamic" rx="5"/><text x="15" y="15" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#7c829d" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#999eb2" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#868690" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#131317" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#999eb2" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#626983" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#d3d5de" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#7c829d" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#e2e4ed" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#b6bac8" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#575861" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#999eb2" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#626983" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#d3d5de" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#7c829d" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#e2e4ed" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#b6bac8" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#868690" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#e2e4ed" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#626983" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#d3d5de" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#626983" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#b6bac8" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/sequoia_monochrome_light.yaml.svg
+++ b/standard/previews/sequoia_monochrome_light.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#edeef2" class="Dynamic" rx="5"/><text x="15" y="15" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#5f6370" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#525666" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#282930" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#d4d5dc" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#525666" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#2e3038" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#50535e" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#5f6370" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#25262d" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#454752" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#42434e" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#525666" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#2e3038" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#50535e" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#5f6370" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#25262d" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#454752" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#282930" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#25262d" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#2e3038" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#50535e" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#2e3038" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#454752" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/sequoia_moonlight_dark.yaml.svg
+++ b/standard/previews/sequoia_moonlight_dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#0f1014" class="Dynamic" rx="5"/><text x="15" y="15" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#c58fff" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#f58ee0" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#868690" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#131317" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#f58ee0" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#8eb6f5" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#9898a6" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#c58fff" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#fdfdfe" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#ffbb88" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#575861" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#f58ee0" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#8eb6f5" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#9898a6" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#c58fff" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#fdfdfe" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#ffbb88" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#868690" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#fdfdfe" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#8eb6f5" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#9898a6" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#8eb6f5" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#ffbb88" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/sequoia_moonlight_light.yaml.svg
+++ b/standard/previews/sequoia_moonlight_light.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#edeef2" class="Dynamic" rx="5"/><text x="15" y="15" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#9a5fd9" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#c94da8" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#282930" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#d4d5dc" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#c94da8" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#4a85d4" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#6a6a78" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#9a5fd9" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#d9884a" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#42434e" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#c94da8" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#4a85d4" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#6a6a78" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#9a5fd9" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#d9884a" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#282930" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#4a85d4" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#6a6a78" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#4a85d4" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#d9884a" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/sequoia_retro_dark.yaml.svg
+++ b/standard/previews/sequoia_retro_dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#0f1014" class="Dynamic" rx="5"/><text x="15" y="15" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#5c87a4" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#829fa7" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#868690" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#131317" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#829fa7" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#648f68" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#da674b" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#5c87a4" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#e8b246" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#a27e57" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#575861" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#e8b246" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#648f68" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#da674b" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#5c87a4" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#829fa7" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#a27e57" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#868690" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#868690" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#e8b246" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#648f68" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#da674b" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#648f68" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#a27e57" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/sequoia_retro_light.yaml.svg
+++ b/standard/previews/sequoia_retro_light.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#edeef2" class="Dynamic" rx="5"/><text x="15" y="15" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#456a82" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#5f7982" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#282930" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#d4d5dc" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#5f7982" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#4a704e" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#bf5238" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#456a82" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#c99730" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#8a6539" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#42434e" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#c99730" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#4a704e" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#bf5238" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#456a82" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#5f7982" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#8a6539" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#282930" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#282930" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#c99730" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#4a704e" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#bf5238" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#4a704e" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#8a6539" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/serendipity_midnight.yaml.svg
+++ b/standard/previews/serendipity_midnight.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#151726" class="Dynamic" rx="5"/><text x="15" y="15" fill="#dee0ef" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#94b8ff" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#ee8679" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#dee0ef" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#dee0ef" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#dee0ef" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#dee0ef" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#232534" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#ee8679" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#5ba2d0" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#a78bfa" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#94b8ff" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#9ccfd8" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#f8d2c9" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#dee0ef" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#dee0ef" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#8d8f9e" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ee8679" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#5ba2d0" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#a78bfa" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#94b8ff" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#9ccfd8" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#f8d2c9" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#dee0ef" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#dee0ef" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#9ccfd8" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#5ba2d0" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#a78bfa" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#5ba2d0" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#f8d2c9" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/serendipity_morning.yaml.svg
+++ b/standard/previews/serendipity_morning.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#f6f7fb" class="Dynamic" rx="5"/><text x="15" y="15" fill="#3f4363" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#6288d8" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#c25a4d" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#3f4363" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#3f4363" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#3f4363" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#3f4363" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#ccd0dc" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#c25a4d" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#2f7aab" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#785fd0" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#6288d8" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#629aa5" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#e58678" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#3f4363" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#3f4363" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#505575" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#c25a4d" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#2f7aab" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#785fd0" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#6288d8" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#629aa5" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#e58678" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#3f4363" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#3f4363" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#629aa5" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#2f7aab" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#785fd0" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#2f7aab" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#e58678" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/serendipity_sunset.yaml.svg
+++ b/standard/previews/serendipity_sunset.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#202231" class="Dynamic" rx="5"/><text x="15" y="15" fill="#dee0ef" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#a0b6e8" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#d1918f" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#dee0ef" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#dee0ef" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#dee0ef" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#dee0ef" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#363847" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#d1918f" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#709bbd" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#a392dc" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#a0b6e8" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#aac9d4" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#d6b4b4" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#dee0ef" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#dee0ef" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#6b6d7c" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#d1918f" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#709bbd" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#a392dc" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#a0b6e8" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#aac9d4" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#d6b4b4" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#dee0ef" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#dee0ef" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#aac9d4" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#709bbd" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#a392dc" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#709bbd" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#d6b4b4" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/sequoia_monochrome_dark.yaml
+++ b/standard/sequoia_monochrome_dark.yaml
@@ -1,0 +1,24 @@
+name: Sequoia Monochrome-Dark
+accent: '#b6bac8'
+background: '#0f1014'
+foreground: '#868690'
+details: darker
+terminal_colors:
+  normal:
+    black: '#131317'
+    red: '#999eb2'
+    green: '#626983'
+    yellow: '#d3d5de'
+    blue: '#7c829d'
+    magenta: '#e2e4ed'
+    cyan: '#b6bac8'
+    white: '#868690'
+  bright:
+    black: '#575861'
+    red: '#999eb2'
+    green: '#626983'
+    yellow: '#d3d5de'
+    blue: '#7c829d'
+    magenta: '#e2e4ed'
+    cyan: '#b6bac8'
+    white: '#868690'

--- a/standard/sequoia_monochrome_light.yaml
+++ b/standard/sequoia_monochrome_light.yaml
@@ -1,0 +1,24 @@
+name: Sequoia Monochrome-Light
+accent: '#454752'
+background: '#edeef2'
+foreground: '#282930'
+details: lighter
+terminal_colors:
+  normal:
+    black: '#d4d5dc'
+    red: '#525666'
+    green: '#2e3038'
+    yellow: '#50535e'
+    blue: '#5f6370'
+    magenta: '#25262d'
+    cyan: '#454752'
+    white: '#282930'
+  bright:
+    black: '#42434e'
+    red: '#525666'
+    green: '#2e3038'
+    yellow: '#50535e'
+    blue: '#5f6370'
+    magenta: '#25262d'
+    cyan: '#454752'
+    white: '#282930'

--- a/standard/sequoia_moonlight_dark.yaml
+++ b/standard/sequoia_moonlight_dark.yaml
@@ -1,0 +1,24 @@
+name: Sequoia Moonlight-Dark
+accent: '#ffbb88'
+background: '#0f1014'
+foreground: '#868690'
+details: darker
+terminal_colors:
+  normal:
+    black: '#131317'
+    red: '#f58ee0'
+    green: '#8eb6f5'
+    yellow: '#9898a6'
+    blue: '#c58fff'
+    magenta: '#fdfdfe'
+    cyan: '#ffbb88'
+    white: '#868690'
+  bright:
+    black: '#575861'
+    red: '#f58ee0'
+    green: '#8eb6f5'
+    yellow: '#9898a6'
+    blue: '#c58fff'
+    magenta: '#fdfdfe'
+    cyan: '#ffbb88'
+    white: '#868690'

--- a/standard/sequoia_moonlight_light.yaml
+++ b/standard/sequoia_moonlight_light.yaml
@@ -1,0 +1,24 @@
+name: Sequoia Moonlight-Light
+accent: '#d9884a'
+background: '#edeef2'
+foreground: '#282930'
+details: lighter
+terminal_colors:
+  normal:
+    black: '#d4d5dc'
+    red: '#c94da8'
+    green: '#4a85d4'
+    yellow: '#6a6a78'
+    blue: '#9a5fd9'
+    magenta: '#282930'
+    cyan: '#d9884a'
+    white: '#282930'
+  bright:
+    black: '#42434e'
+    red: '#c94da8'
+    green: '#4a85d4'
+    yellow: '#6a6a78'
+    blue: '#9a5fd9'
+    magenta: '#282930'
+    cyan: '#d9884a'
+    white: '#282930'

--- a/standard/sequoia_retro_dark.yaml
+++ b/standard/sequoia_retro_dark.yaml
@@ -1,0 +1,24 @@
+name: Sequoia Retro-Dark
+accent: '#a27e57'
+background: '#0f1014'
+foreground: '#868690'
+details: darker
+terminal_colors:
+  normal:
+    black: '#131317'
+    red: '#829fa7'
+    green: '#648f68'
+    yellow: '#da674b'
+    blue: '#5c87a4'
+    magenta: '#e8b246'
+    cyan: '#a27e57'
+    white: '#868690'
+  bright:
+    black: '#575861'
+    red: '#e8b246'
+    green: '#648f68'
+    yellow: '#da674b'
+    blue: '#5c87a4'
+    magenta: '#829fa7'
+    cyan: '#a27e57'
+    white: '#868690'

--- a/standard/sequoia_retro_light.yaml
+++ b/standard/sequoia_retro_light.yaml
@@ -1,0 +1,24 @@
+name: Sequoia Retro-Light
+accent: '#8a6539'
+background: '#edeef2'
+foreground: '#282930'
+details: lighter
+terminal_colors:
+  normal:
+    black: '#d4d5dc'
+    red: '#5f7982'
+    green: '#4a704e'
+    yellow: '#bf5238'
+    blue: '#456a82'
+    magenta: '#c99730'
+    cyan: '#8a6539'
+    white: '#282930'
+  bright:
+    black: '#42434e'
+    red: '#c99730'
+    green: '#4a704e'
+    yellow: '#bf5238'
+    blue: '#456a82'
+    magenta: '#5f7982'
+    cyan: '#8a6539'
+    white: '#282930'

--- a/standard/serendipity_midnight.yaml
+++ b/standard/serendipity_midnight.yaml
@@ -1,0 +1,24 @@
+name: Serendipity Midnight
+accent: '#f8d2c9'
+background: '#151726'
+foreground: '#dee0ef'
+details: darker
+terminal_colors:
+  normal:
+    black: '#232534'
+    red: '#ee8679'
+    green: '#5ba2d0'
+    yellow: '#a78bfa'
+    blue: '#94b8ff'
+    magenta: '#9ccfd8'
+    cyan: '#f8d2c9'
+    white: '#dee0ef'
+  bright:
+    black: '#8d8f9e'
+    red: '#ee8679'
+    green: '#5ba2d0'
+    yellow: '#a78bfa'
+    blue: '#94b8ff'
+    magenta: '#9ccfd8'
+    cyan: '#f8d2c9'
+    white: '#dee0ef'

--- a/standard/serendipity_morning.yaml
+++ b/standard/serendipity_morning.yaml
@@ -1,0 +1,24 @@
+name: Serendipity Morning
+accent: '#e58678'
+background: '#f6f7fb'
+foreground: '#3f4363'
+details: lighter
+terminal_colors:
+  normal:
+    black: '#ccd0dc'
+    red: '#c25a4d'
+    green: '#2f7aab'
+    yellow: '#785fd0'
+    blue: '#6288d8'
+    magenta: '#629aa5'
+    cyan: '#e58678'
+    white: '#3f4363'
+  bright:
+    black: '#505575'
+    red: '#c25a4d'
+    green: '#2f7aab'
+    yellow: '#785fd0'
+    blue: '#6288d8'
+    magenta: '#629aa5'
+    cyan: '#e58678'
+    white: '#3f4363'

--- a/standard/serendipity_sunset.yaml
+++ b/standard/serendipity_sunset.yaml
@@ -1,0 +1,24 @@
+name: Serendipity Sunset
+accent: '#d6b4b4'
+background: '#202231'
+foreground: '#dee0ef'
+details: darker
+terminal_colors:
+  normal:
+    black: '#363847'
+    red: '#d1918f'
+    green: '#709bbd'
+    yellow: '#a392dc'
+    blue: '#a0b6e8'
+    magenta: '#aac9d4'
+    cyan: '#d6b4b4'
+    white: '#dee0ef'
+  bright:
+    black: '#6b6d7c'
+    red: '#d1918f'
+    green: '#709bbd'
+    yellow: '#a392dc'
+    blue: '#a0b6e8'
+    magenta: '#aac9d4'
+    cyan: '#d6b4b4'
+    white: '#dee0ef'


### PR DESCRIPTION
## Summary

Adds **Serendipity** (Midnight, Morning, Sunset) and **Sequoia** (Moonlight, Monochrome, Retro — dark and light) to the standard Warp themes directory.

Source: [Serendipity-Theme](https://github.com/Serendipity-Theme) and [Sequoia-Theme](https://github.com/Sequoia-Theme)

## Test plan

- [x] Generated preview SVGs via `scripts/gen_theme_previews.py standard`
- [ ] Import a theme in Warp Settings → Appearance
- [ ] Verify terminal ANSI colors and accent in both dark and light variants


Made with [Cursor](https://cursor.com)