### PR TITLE
Add orng theme

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -81,6 +81,7 @@
 |**[Omni](omni.yaml)**:|<img src='previews/omni.yaml.svg' width='300'>|
 |**[One Dark](one_dark.yaml)**:|<img src='previews/one_dark.yaml.svg' width='300'>|
 |**[One Monokai](one_monokai.yaml)**:|<img src='previews/one_monokai.yaml.svg' width='300'>|
+|**[Orng](orng.yaml)**:|<img src='previews/orng.yaml.svg' width='300'>|
 |**[Outrun](outrun.yaml)**:|<img src='previews/outrun.yaml.svg' width='300'>|
 |**[Palenight](palenight.yaml)**:|<img src='previews/palenight.yaml.svg' width='300'>|
 |**[Panda Syntax](panda_syntax.yaml)**:|<img src='previews/panda_syntax.yaml.svg' width='300'>|
@@ -104,6 +105,9 @@
 |**[Snazzy Green](snazzy_green.yaml)**:|<img src='previews/snazzy_green.yaml.svg' width='300'>|
 |**[Snazzy Red](snazzy_red.yaml)**:|<img src='previews/snazzy_red.yaml.svg' width='300'>|
 |**[Soft One Dark](soft_one_dark.yaml)**:|<img src='previews/soft_one_dark.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Cream](soft_tactile_warp_cream.yaml)**:|<img src='previews/soft_tactile_warp_cream.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Dark](soft_tactile_warp_dark.yaml)**:|<img src='previews/soft_tactile_warp_dark.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Light](soft_tactile_warp_light.yaml)**:|<img src='previews/soft_tactile_warp_light.yaml.svg' width='300'>|
 |**[Solarized Dark](solarized_dark.yaml)**:|<img src='previews/solarized_dark.yaml.svg' width='300'>|
 |**[Solarized Light](solarized_light.yaml)**:|<img src='previews/solarized_light.yaml.svg' width='300'>|
 |**[Spaceduck](spaceduck.yaml)**:|<img src='previews/spaceduck.yaml.svg' width='300'>|
@@ -128,6 +132,6 @@
 |**[Xterm](xterm.yaml)**:|<img src='previews/xterm.yaml.svg' width='300'>|
 |**[Zenbones Dark](zenbones_dark.yaml)**:|<img src='previews/zenbones_dark.yaml.svg' width='300'>|
 |**[Zenbones Light](zenbones_light.yaml)**:|<img src='previews/zenbones_light.yaml.svg' width='300'>|
-|**[Zenburn Colorblind High Contrast](zenburn_colorblind_high_contrast.yaml)**:|<img src='previews/zenburn_colorblind_high_contrast.yaml.svg' width='300'>|
-|**[Zenburn Colorblind](zenburn_colorblind.yaml)**:|<img src='previews/zenburn_colorblind.yaml.svg' width='300'>|
 |**[Zenburn](zenburn.yaml)**:|<img src='previews/zenburn.yaml.svg' width='300'>|
+|**[Zenburn Colorblind](zenburn_colorblind.yaml)**:|<img src='previews/zenburn_colorblind.yaml.svg' width='300'>|
+|**[Zenburn Colorblind High Contrast](zenburn_colorblind_high_contrast.yaml)**:|<img src='previews/zenburn_colorblind_high_contrast.yaml.svg' width='300'>|

--- a/standard/orng.yaml
+++ b/standard/orng.yaml
@@ -1,0 +1,26 @@
+name: orng
+# Cloudflare-inspired dark theme, ported from the orng VS Code theme
+# https://github.com/kafwe/orng
+accent: '#EC5B2B'
+background: '#161A22'
+foreground: '#EEEEEE'
+details: darker
+terminal_colors:
+  normal:
+    black: '#161A22'
+    red: '#E06C75'
+    green: '#7FD88F'
+    yellow: '#E5C07B'
+    blue: '#56B6C2'
+    magenta: '#EE7948'
+    cyan: '#56B6C2'
+    white: '#EEEEEE'
+  bright:
+    black: '#606060'
+    red: '#F28B93'
+    green: '#A3E8B0'
+    yellow: '#F0D49A'
+    blue: '#7CCCD5'
+    magenta: '#F5A07A'
+    cyan: '#7CCCD5'
+    white: '#FFFFFF'

--- a/standard/previews/orng.yaml.svg
+++ b/standard/previews/orng.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#161A22" class="Dynamic" rx="5"/><text x="15" y="15" fill="#EEEEEE" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#56B6C2" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#E06C75" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#EEEEEE" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#EEEEEE" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#EEEEEE" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#EEEEEE" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#161A22" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#E06C75" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#7FD88F" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#E5C07B" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#56B6C2" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#EE7948" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#56B6C2" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#EEEEEE" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#EEEEEE" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#606060" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#F28B93" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#A3E8B0" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#F0D49A" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#7CCCD5" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#F5A07A" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#7CCCD5" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#FFFFFF" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#EEEEEE" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#EE7948" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#7FD88F" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#E5C07B" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#7FD88F" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#EC5B2B" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION

## Name of theme

orng

## Description

Adds a new standard Warp theme based on the [orng VS Code theme](https://github.com/kafwe/orng). It is a warm, dark theme with an orange accent inspired by the Cloudflare palette.

## How Has This Been Tested?

- Ran the repo's preview generator:
  ```bash
  python3 ./scripts/gen_theme_previews.py standard
  ```
- Verified that `standard/orng.yaml`, `standard/previews/orng.yaml.svg`, and the updated `standard/README.md` were generated correctly.
- Confirmed the YAML is valid and includes all required Warp theme keys (`name`, `accent`, `background`, `foreground`, `details`, `terminal_colors`).

## Notes

No custom background image is included.
