### PR TITLE
Add Flynt dark and light themes

### DIFF
--- a/standard/flynt-dark.yaml
+++ b/standard/flynt-dark.yaml
@@ -1,0 +1,23 @@
+accent: '#C69F2A'
+background: '#100E0C'
+details: darker
+foreground: '#F5EDD8'
+terminal_colors:
+  bright:
+    black: '#403C38'
+    blue: '#7AA6CD'
+    cyan: '#7EC8C2'
+    green: '#93AE42'
+    magenta: '#D175A6'
+    red: '#DF7168'
+    white: '#F5EDD8'
+    yellow: '#DFC168'
+  normal:
+    black: '#1C1916'
+    blue: '#427BAE'
+    cyan: '#48A8A0'
+    green: '#60A848'
+    magenta: '#B43C7C'
+    red: '#C6372A'
+    white: '#D8CEBC'
+    yellow: '#C69F2A'

--- a/standard/flynt-light.yaml
+++ b/standard/flynt-light.yaml
@@ -1,0 +1,23 @@
+accent: '#C69F2A'
+background: '#FFFCEF'
+details: lighter
+foreground: '#1A1512'
+terminal_colors:
+  bright:
+    black: '#C0B9AA'
+    blue: '#7AA6CD'
+    cyan: '#7EC8C2'
+    green: '#93AE42'
+    magenta: '#D175A6'
+    red: '#DF7168'
+    white: '#1A1512'
+    yellow: '#DFC168'
+  normal:
+    black: '#F2EDDE'
+    blue: '#427BAE'
+    cyan: '#48A8A0'
+    green: '#60A848'
+    magenta: '#B43C7C'
+    red: '#C6372A'
+    white: '#3D3228'
+    yellow: '#C69F2A'

--- a/standard/previews/flynt-dark.yaml.svg
+++ b/standard/previews/flynt-dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#100E0C" class="Dynamic" rx="5"/><text x="15" y="15" fill="#F5EDD8" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#427BAE" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#C6372A" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#F5EDD8" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#F5EDD8" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#F5EDD8" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#F5EDD8" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1C1916" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#C6372A" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#60A848" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#C69F2A" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#427BAE" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#B43C7C" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#48A8A0" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#D8CEBC" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#F5EDD8" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#403C38" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#DF7168" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#93AE42" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#DFC168" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#7AA6CD" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#D175A6" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#7EC8C2" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#F5EDD8" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#F5EDD8" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#B43C7C" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#60A848" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#C69F2A" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#60A848" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#C69F2A" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/flynt-light.yaml.svg
+++ b/standard/previews/flynt-light.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#FFFCEF" class="Dynamic" rx="5"/><text x="15" y="15" fill="#1A1512" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#427BAE" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#C6372A" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#1A1512" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#1A1512" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#1A1512" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#1A1512" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#F2EDDE" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#C6372A" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#60A848" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#C69F2A" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#427BAE" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#B43C7C" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#48A8A0" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#3D3228" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#1A1512" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#C0B9AA" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#DF7168" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#93AE42" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#DFC168" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#7AA6CD" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#D175A6" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#7EC8C2" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#1A1512" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#1A1512" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#B43C7C" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#60A848" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#C69F2A" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#60A848" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#C69F2A" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
## Name of theme

Flynt Dark and Flynt Light

## How Has This Been Tested?

Yes - ran `python3.11 ./scripts/gen_theme_previews.py standard`. Preview SVGs are included.

## Notes

Flynt is a warm-toned color theme with amber as the primary accent. Targets editors and terminals. Full palette and docs at https://flynt-theme.github.io/flynt.