### PR TITLE
Add HearthCode Moss and Ember themes

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -51,6 +51,10 @@
 |**[Gruvbox Material](gruvbox_material.yaml)**:|<img src='previews/gruvbox_material.yaml.svg' width='300'>|
 |**[Hackthebox](hackthebox.yaml)**:|<img src='previews/hackthebox.yaml.svg' width='300'>|
 |**[Halcyon](halcyon.yaml)**:|<img src='previews/halcyon.yaml.svg' width='300'>|
+|**[Hearthcode Ember Dark](hearthcode_ember_dark.yaml)**:|<img src='previews/hearthcode_ember_dark.yaml.svg' width='300'>|
+|**[Hearthcode Ember Light](hearthcode_ember_light.yaml)**:|<img src='previews/hearthcode_ember_light.yaml.svg' width='300'>|
+|**[Hearthcode Moss Dark](hearthcode_moss_dark.yaml)**:|<img src='previews/hearthcode_moss_dark.yaml.svg' width='300'>|
+|**[Hearthcode Moss Light](hearthcode_moss_light.yaml)**:|<img src='previews/hearthcode_moss_light.yaml.svg' width='300'>|
 |**[High Contrast](high_contrast.yaml)**:|<img src='previews/high_contrast.yaml.svg' width='300'>|
 |**[Horizon Dark](horizon_dark.yaml)**:|<img src='previews/horizon_dark.yaml.svg' width='300'>|
 |**[Hyper](hyper.yaml)**:|<img src='previews/hyper.yaml.svg' width='300'>|

--- a/standard/hearthcode_ember_dark.yaml
+++ b/standard/hearthcode_ember_dark.yaml
@@ -1,0 +1,23 @@
+accent: "#dc8d46"
+background: "#1f1a17"
+details: darker
+foreground: "#d3c9b8"
+terminal_colors:
+  bright:
+    black: "#655c4f"
+    red: "#d37962"
+    green: "#96b986"
+    yellow: "#c7a95b"
+    blue: "#86a4bc"
+    magenta: "#c5a080"
+    cyan: "#8cb9b3"
+    white: "#e8ddca"
+  normal:
+    black: "#2f2921"
+    red: "#c66a52"
+    green: "#87ab70"
+    yellow: "#b89543"
+    blue: "#6f8ca4"
+    magenta: "#b38b6a"
+    cyan: "#79a8a2"
+    white: "#d3c9b8"

--- a/standard/hearthcode_ember_light.yaml
+++ b/standard/hearthcode_ember_light.yaml
@@ -1,0 +1,23 @@
+accent: "#4c7688"
+background: "#ecdfcd"
+details: lighter
+foreground: "#30261b"
+terminal_colors:
+  bright:
+    black: "#7f6d53"
+    red: "#be4a2a"
+    green: "#3b7f38"
+    yellow: "#927a3e"
+    blue: "#3a6080"
+    magenta: "#885428"
+    cyan: "#3a7060"
+    white: "#2f210e"
+  normal:
+    black: "#3a3020"
+    red: "#ad3518"
+    green: "#2e6a2c"
+    yellow: "#7f6531"
+    blue: "#2a5070"
+    magenta: "#784418"
+    cyan: "#2a6050"
+    white: "#624a2c"

--- a/standard/hearthcode_moss_dark.yaml
+++ b/standard/hearthcode_moss_dark.yaml
@@ -1,0 +1,23 @@
+accent: "#8bb49e"
+background: "#1b1d1a"
+details: darker
+foreground: "#d2bea2"
+terminal_colors:
+  bright:
+    black: "#675d52"
+    red: "#ee8376"
+    green: "#b6c97f"
+    yellow: "#deba72"
+    blue: "#92bbb1"
+    magenta: "#dc9fb2"
+    cyan: "#9bc099"
+    white: "#f1e6d4"
+  normal:
+    black: "#1d201f"
+    red: "#e06c5e"
+    green: "#9fb86f"
+    yellow: "#d2ab61"
+    blue: "#79a89f"
+    magenta: "#ca8ea5"
+    cyan: "#8fb686"
+    white: "#d6c3a3"

--- a/standard/hearthcode_moss_light.yaml
+++ b/standard/hearthcode_moss_light.yaml
@@ -1,0 +1,23 @@
+accent: "#486a59"
+background: "#e7e5d8"
+details: lighter
+foreground: "#342d28"
+terminal_colors:
+  bright:
+    black: "#8c7c69"
+    red: "#c9675c"
+    green: "#79914c"
+    yellow: "#ab8034"
+    blue: "#658d85"
+    magenta: "#b9758b"
+    cyan: "#70946f"
+    white: "#2d241e"
+  normal:
+    black: "#3a342e"
+    red: "#ba5146"
+    green: "#718246"
+    yellow: "#9d7124"
+    blue: "#517d76"
+    magenta: "#a26179"
+    cyan: "#608763"
+    white: "#43382e"

--- a/standard/previews/hearthcode_ember_dark.yaml.svg
+++ b/standard/previews/hearthcode_ember_dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#1f1a17" class="Dynamic" rx="5"/><text x="15" y="15" fill="#d3c9b8" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#6f8ca4" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#c66a52" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#d3c9b8" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#d3c9b8" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#d3c9b8" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#d3c9b8" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#2f2921" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#c66a52" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#87ab70" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#b89543" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#6f8ca4" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#b38b6a" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#79a8a2" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#d3c9b8" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#d3c9b8" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#655c4f" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#d37962" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#96b986" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#c7a95b" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#86a4bc" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#c5a080" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#8cb9b3" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#e8ddca" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#d3c9b8" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#b38b6a" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#87ab70" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#b89543" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#87ab70" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#dc8d46" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/hearthcode_ember_light.yaml.svg
+++ b/standard/previews/hearthcode_ember_light.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#ecdfcd" class="Dynamic" rx="5"/><text x="15" y="15" fill="#30261b" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#2a5070" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#ad3518" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#30261b" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#30261b" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#30261b" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#30261b" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#3a3020" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#ad3518" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#2e6a2c" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#7f6531" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#2a5070" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#784418" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#2a6050" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#624a2c" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#30261b" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#7f6d53" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#be4a2a" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#3b7f38" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#927a3e" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#3a6080" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#885428" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#3a7060" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#2f210e" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#30261b" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#784418" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#2e6a2c" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#7f6531" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#2e6a2c" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#4c7688" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/hearthcode_moss_dark.yaml.svg
+++ b/standard/previews/hearthcode_moss_dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#1b1d1a" class="Dynamic" rx="5"/><text x="15" y="15" fill="#d2bea2" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#79a89f" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#e06c5e" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#d2bea2" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#d2bea2" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#d2bea2" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#d2bea2" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1d201f" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#e06c5e" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#9fb86f" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#d2ab61" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#79a89f" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#ca8ea5" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#8fb686" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#d6c3a3" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#d2bea2" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#675d52" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ee8376" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#b6c97f" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#deba72" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#92bbb1" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#dc9fb2" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#9bc099" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#f1e6d4" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#d2bea2" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#ca8ea5" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#9fb86f" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#d2ab61" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#9fb86f" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#8bb49e" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/hearthcode_moss_light.yaml.svg
+++ b/standard/previews/hearthcode_moss_light.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#e7e5d8" class="Dynamic" rx="5"/><text x="15" y="15" fill="#342d28" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#517d76" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#ba5146" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#342d28" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#342d28" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#342d28" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#342d28" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#3a342e" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#ba5146" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#718246" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#9d7124" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#517d76" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#a26179" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#608763" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#43382e" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#342d28" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#8c7c69" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#c9675c" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#79914c" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#ab8034" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#658d85" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#b9758b" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#70946f" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#2d241e" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#342d28" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#a26179" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#718246" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#9d7124" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#718246" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#486a59" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
Adds the four official HearthCode terminal variants:

- HearthCode Moss Dark
- HearthCode Moss Light
- HearthCode Ember Dark
- HearthCode Ember Light

The palettes are generated from HearthCode’s shared color-system source and keep the same terminal ANSI contract as the editor themes. Moss Dark is the recommended default; Ember remains a full first-class direction.

Source: https://github.com/hearth-code/HearthTheme/tree/main/terminal/warp

Validation:
- Parsed all four YAML files with PyYAML
- Verified normal and bright 8-color groups
- Generated and included previews with `scripts/gen_theme_previews.py standard`