### PR TITLE
Add Cyberpunk Noir theme

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -25,6 +25,7 @@
 |**[Cyberpunk-neon](cyberpunk-neon.yaml)**:|<img src='previews/cyberpunk-neon.yaml.svg' width='300'>|
 |**[Cyberpunk-night City](cyberpunk-night_city.yaml)**:|<img src='previews/cyberpunk-night_city.yaml.svg' width='300'>|
 |**[Cyberpunk-v](cyberpunk-v.yaml)**:|<img src='previews/cyberpunk-v.yaml.svg' width='300'>|
+|**[Cyberpunk Noir](cyberpunk_noir.yaml)**:|<img src='previews/cyberpunk_noir.yaml.svg' width='300'>|
 |**[Daobeam](daobeam.yaml)**:|<img src='previews/daobeam.yaml.svg' width='300'>|
 |**[Darcula](darcula.yaml)**:|<img src='previews/darcula.yaml.svg' width='300'>|
 |**[Dark-pinkish](dark-pinkish.yaml)**:|<img src='previews/dark-pinkish.yaml.svg' width='300'>|
@@ -104,6 +105,9 @@
 |**[Snazzy Green](snazzy_green.yaml)**:|<img src='previews/snazzy_green.yaml.svg' width='300'>|
 |**[Snazzy Red](snazzy_red.yaml)**:|<img src='previews/snazzy_red.yaml.svg' width='300'>|
 |**[Soft One Dark](soft_one_dark.yaml)**:|<img src='previews/soft_one_dark.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Cream](soft_tactile_warp_cream.yaml)**:|<img src='previews/soft_tactile_warp_cream.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Dark](soft_tactile_warp_dark.yaml)**:|<img src='previews/soft_tactile_warp_dark.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Light](soft_tactile_warp_light.yaml)**:|<img src='previews/soft_tactile_warp_light.yaml.svg' width='300'>|
 |**[Solarized Dark](solarized_dark.yaml)**:|<img src='previews/solarized_dark.yaml.svg' width='300'>|
 |**[Solarized Light](solarized_light.yaml)**:|<img src='previews/solarized_light.yaml.svg' width='300'>|
 |**[Spaceduck](spaceduck.yaml)**:|<img src='previews/spaceduck.yaml.svg' width='300'>|
@@ -128,6 +132,6 @@
 |**[Xterm](xterm.yaml)**:|<img src='previews/xterm.yaml.svg' width='300'>|
 |**[Zenbones Dark](zenbones_dark.yaml)**:|<img src='previews/zenbones_dark.yaml.svg' width='300'>|
 |**[Zenbones Light](zenbones_light.yaml)**:|<img src='previews/zenbones_light.yaml.svg' width='300'>|
-|**[Zenburn Colorblind High Contrast](zenburn_colorblind_high_contrast.yaml)**:|<img src='previews/zenburn_colorblind_high_contrast.yaml.svg' width='300'>|
-|**[Zenburn Colorblind](zenburn_colorblind.yaml)**:|<img src='previews/zenburn_colorblind.yaml.svg' width='300'>|
 |**[Zenburn](zenburn.yaml)**:|<img src='previews/zenburn.yaml.svg' width='300'>|
+|**[Zenburn Colorblind](zenburn_colorblind.yaml)**:|<img src='previews/zenburn_colorblind.yaml.svg' width='300'>|
+|**[Zenburn Colorblind High Contrast](zenburn_colorblind_high_contrast.yaml)**:|<img src='previews/zenburn_colorblind_high_contrast.yaml.svg' width='300'>|

--- a/standard/cyberpunk_noir.yaml
+++ b/standard/cyberpunk_noir.yaml
@@ -1,0 +1,23 @@
+accent: "#ff2e97"
+background: "#0b0b14"
+details: darker
+foreground: "#c8c8da"
+terminal_colors:
+  bright:
+    black: "#6d5d8f"
+    blue: "#5b8cff"
+    cyan: "#5bffe8"
+    green: "#7bff5c"
+    magenta: "#ff6bc1"
+    red: "#ff5c7a"
+    white: "#ffffff"
+    yellow: "#fff75c"
+  normal:
+    black: "#1a1a2e"
+    blue: "#2e8bff"
+    cyan: "#00f5d4"
+    green: "#39ff14"
+    magenta: "#ff2e97"
+    red: "#ff2d55"
+    white: "#c8c8da"
+    yellow: "#fcee0a"

--- a/standard/previews/cyberpunk_noir.yaml.svg
+++ b/standard/previews/cyberpunk_noir.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#0b0b14" class="Dynamic" rx="5"/><text x="15" y="15" fill="#c8c8da" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#2e8bff" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#ff2d55" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#c8c8da" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#c8c8da" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#c8c8da" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#c8c8da" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1a1a2e" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#ff2d55" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#39ff14" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#fcee0a" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#2e8bff" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#ff2e97" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#00f5d4" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#c8c8da" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#c8c8da" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#6d5d8f" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#ff5c7a" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#7bff5c" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#fff75c" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#5b8cff" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#ff6bc1" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#5bffe8" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#ffffff" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#c8c8da" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#ff2e97" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#39ff14" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#fcee0a" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#39ff14" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#ff2e97" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
## Discord username (optional)

4nrry

(Discord dropped the `#XXXX` discriminator, so this is the full modern username.)

## Name of theme

**Cyberpunk Noir** (`standard/cyberpunk_noir.yaml`)

A neon theme built around one constraint: **every ANSI slot is the colour its name claims**, and each `bright` is a hotter version of its `normal` rather than a different hue or a gray.

That constraint is the reason the theme exists. Several existing neon/cyberpunk themes in this repo were auto-generated from Alacritty collections, and the conversion mapped tones onto ANSI slots by position rather than by hue, so the slot names no longer describe their colours. A few examples from the repo as it stands:

- `base16/base16_papercolor_dark.yaml`: `normal.blue` is `#ff5faf` (pink), `normal.cyan` is `#ffaf00` (orange), `bright.yellow` is `#5faf00` (green).
- `standard/cyberpunk-night_city.yaml` and `standard/cyberpunk-v.yaml`: the entire `bright` row is grayscale, e.g. `bright.blue` `#b8b8b8`, `bright.magenta` `#e8e8e8`.

Anything that requests a colour by name (shell prompts, status lines, syntax highlighting) gets an arbitrary hue back on those themes. Cyberpunk Noir keeps the mapping honest so the neon actually lands where a tool asks for it.

One other deliberate choice: `bright.black` is a slate violet at roughly 5:1 contrast against the background, not a near-black. It is the slot most tools reach for when they want dim-but-readable text (comments, secondary metadata), and pushing it toward the background is what makes that text unreadable.

## How Has This Been Tested?

Yes, ran `python3 ./scripts/gen_theme_previews.py standard` as directed.

One thing worth flagging: regenerating the previews produced changes beyond my own row. `standard/README.md` on `main` was missing rows for `soft_tactile_warp_cream`, `soft_tactile_warp_dark` and `soft_tactile_warp_light` (the yaml and svg files are already committed, only the README rows were absent), and it had `zenburn_colorblind_high_contrast` sorted before `zenburn_colorblind`. The script's output corrects both. I left those in rather than hand-trimming the file, so that the committed README matches exactly what the script generates. Happy to strip them into a separate PR if you would rather keep this one to a single theme.

No custom background image, so no licensing or binary-size concerns.

## Notes

Every other preview SVG regenerated byte-identical, so the diff is limited to the new theme, its preview, and the README rows above.