### PR TITLE
Add Oceanic Custom theme

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -77,6 +77,7 @@
 |**[Night Owl](night_owl.yaml)**:|<img src='previews/night_owl.yaml.svg' width='300'>|
 |**[Nightfly](nightfly.yaml)**:|<img src='previews/nightfly.yaml.svg' width='300'>|
 |**[Nord](nord.yaml)**:|<img src='previews/nord.yaml.svg' width='300'>|
+|**[Oceanic-custom](oceanic-custom.yaml)**:|<img src='previews/oceanic-custom.yaml.svg' width='300'>|
 |**[Oceanic Next](oceanic_next.yaml)**:|<img src='previews/oceanic_next.yaml.svg' width='300'>|
 |**[Omni](omni.yaml)**:|<img src='previews/omni.yaml.svg' width='300'>|
 |**[One Dark](one_dark.yaml)**:|<img src='previews/one_dark.yaml.svg' width='300'>|
@@ -104,6 +105,9 @@
 |**[Snazzy Green](snazzy_green.yaml)**:|<img src='previews/snazzy_green.yaml.svg' width='300'>|
 |**[Snazzy Red](snazzy_red.yaml)**:|<img src='previews/snazzy_red.yaml.svg' width='300'>|
 |**[Soft One Dark](soft_one_dark.yaml)**:|<img src='previews/soft_one_dark.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Cream](soft_tactile_warp_cream.yaml)**:|<img src='previews/soft_tactile_warp_cream.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Dark](soft_tactile_warp_dark.yaml)**:|<img src='previews/soft_tactile_warp_dark.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Light](soft_tactile_warp_light.yaml)**:|<img src='previews/soft_tactile_warp_light.yaml.svg' width='300'>|
 |**[Solarized Dark](solarized_dark.yaml)**:|<img src='previews/solarized_dark.yaml.svg' width='300'>|
 |**[Solarized Light](solarized_light.yaml)**:|<img src='previews/solarized_light.yaml.svg' width='300'>|
 |**[Spaceduck](spaceduck.yaml)**:|<img src='previews/spaceduck.yaml.svg' width='300'>|
@@ -128,6 +132,6 @@
 |**[Xterm](xterm.yaml)**:|<img src='previews/xterm.yaml.svg' width='300'>|
 |**[Zenbones Dark](zenbones_dark.yaml)**:|<img src='previews/zenbones_dark.yaml.svg' width='300'>|
 |**[Zenbones Light](zenbones_light.yaml)**:|<img src='previews/zenbones_light.yaml.svg' width='300'>|
-|**[Zenburn Colorblind High Contrast](zenburn_colorblind_high_contrast.yaml)**:|<img src='previews/zenburn_colorblind_high_contrast.yaml.svg' width='300'>|
-|**[Zenburn Colorblind](zenburn_colorblind.yaml)**:|<img src='previews/zenburn_colorblind.yaml.svg' width='300'>|
 |**[Zenburn](zenburn.yaml)**:|<img src='previews/zenburn.yaml.svg' width='300'>|
+|**[Zenburn Colorblind](zenburn_colorblind.yaml)**:|<img src='previews/zenburn_colorblind.yaml.svg' width='300'>|
+|**[Zenburn Colorblind High Contrast](zenburn_colorblind_high_contrast.yaml)**:|<img src='previews/zenburn_colorblind_high_contrast.yaml.svg' width='300'>|

--- a/standard/oceanic-custom.yaml
+++ b/standard/oceanic-custom.yaml
@@ -1,0 +1,24 @@
+name: Oceanic Custom
+accent: '#5CCFE6'
+background: '#263238'
+foreground: '#D5DBE5'
+details: darker
+terminal_colors:
+  normal:
+    black: '#01060E'
+    red: '#F28779'
+    green: '#BAE67E'
+    yellow: '#FFD580'
+    blue: '#5CCFE6'
+    magenta: '#D4BFFF'
+    cyan: '#95E6CB'
+    white: '#C7C7C7'
+  bright:
+    black: '#686868'
+    red: '#F28779'
+    green: '#BAE67E'
+    yellow: '#FFD580'
+    blue: '#73D0FF'
+    magenta: '#D4BFFF'
+    cyan: '#95E6CB'
+    white: '#FFFFFF'

--- a/standard/previews/oceanic-custom.yaml.svg
+++ b/standard/previews/oceanic-custom.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#263238" class="Dynamic" rx="5"/><text x="15" y="15" fill="#D5DBE5" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#5CCFE6" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#F28779" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#D5DBE5" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#D5DBE5" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#D5DBE5" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#D5DBE5" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#01060E" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#F28779" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#BAE67E" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#FFD580" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#5CCFE6" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#D4BFFF" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#95E6CB" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#C7C7C7" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#D5DBE5" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#686868" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#F28779" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#BAE67E" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#FFD580" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#73D0FF" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#D4BFFF" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#95E6CB" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#FFFFFF" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#D5DBE5" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#D4BFFF" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#BAE67E" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#FFD580" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#BAE67E" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#5CCFE6" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
Adds **Oceanic Custom**, a dark theme with cyan accents (oceanic-inspired palette).

- `background` `#263238` · `foreground` `#D5DBE5` · `accent` `#5CCFE6`
- Ported from my VS Code / Cursor theme, which has **2.3k+ installs on Open VSX**: https://open-vsx.org/extension/facundo-malgieri/oceanic-custom
- Warp repo: https://github.com/FacundoMalgieri/oceanic-warp
- Preview generated via `scripts/gen_theme_previews.py standard`

Preview:

<img src='https://raw.githubusercontent.com/FacundoMalgieri/themes/add-oceanic-custom/standard/previews/oceanic-custom.yaml.svg' width='400'>