### PR TITLE
Add Catppuccin Latte Glass theme

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -16,6 +16,7 @@
 |**[Breeze](breeze.yaml)**:|<img src='previews/breeze.yaml.svg' width='300'>|
 |**[Campbell](campbell.yaml)**:|<img src='previews/campbell.yaml.svg' width='300'>|
 |**[Catppuccin](catppuccin.yaml)**:|<img src='previews/catppuccin.yaml.svg' width='300'>|
+|**[Catppuccin Latte Glass](catppuccin_latte_glass.yml)**:|<img src='previews/catppuccin_latte_glass.yml.svg' width='300'>|
 |**[Challenger Deep](challenger_deep.yaml)**:|<img src='previews/challenger_deep.yaml.svg' width='300'>|
 |**[Cherry](cherry.yaml)**:|<img src='previews/cherry.yaml.svg' width='300'>|
 |**[Classic Vivid](classic_vivid.yaml)**:|<img src='previews/classic_vivid.yaml.svg' width='300'>|

--- a/standard/catppuccin_latte_glass.yml
+++ b/standard/catppuccin_latte_glass.yml
@@ -1,0 +1,39 @@
+# Catppuccin Latte Glass
+# A light theme based on the Catppuccin Latte palette (https://github.com/catppuccin/catppuccin, MIT),
+# with a lavender-to-pink accent gradient and an optional soft pastel "glow" background
+# image generated from the Latte accent colors (lavender, mauve, pink, sky).
+#
+# To enable the background image (original, generated for this theme, CC0):
+# 1. Download it:
+#    curl -sSL https://github.com/rhlsthrm/themes/releases/download/latte-glass-assets/latte_glow.jpg -o ~/.warp/themes/catppuccin_latte_glass_bg.jpg
+# 2. Uncomment the background_image section below.
+name: Catppuccin Latte Glass
+background: '#eff1f5'
+accent:
+  left: '#7287fd'
+  right: '#ea76cb'
+foreground: '#4c4f69'
+cursor: '#8839ef'
+details: lighter
+# background_image:
+#   path: catppuccin_latte_glass_bg.jpg
+#   opacity: 30
+terminal_colors:
+  normal:
+    black: '#5c5f77'
+    red: '#d20f39'
+    green: '#40a02b'
+    yellow: '#df8e1d'
+    blue: '#1e66f5'
+    magenta: '#ea76cb'
+    cyan: '#179299'
+    white: '#acb0be'
+  bright:
+    black: '#6c6f85'
+    red: '#d20f39'
+    green: '#40a02b'
+    yellow: '#df8e1d'
+    blue: '#1e66f5'
+    magenta: '#ea76cb'
+    cyan: '#179299'
+    white: '#bcc0cc'

--- a/standard/previews/catppuccin_latte_glass.yml.svg
+++ b/standard/previews/catppuccin_latte_glass.yml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#eff1f5" class="Dynamic" rx="5"/><text x="15" y="15" fill="#4c4f69" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#1e66f5" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#d20f39" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#4c4f69" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#4c4f69" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#4c4f69" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#4c4f69" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#5c5f77" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#d20f39" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#40a02b" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#df8e1d" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#1e66f5" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#ea76cb" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#179299" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#acb0be" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#4c4f69" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#6c6f85" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#d20f39" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#40a02b" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#df8e1d" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#1e66f5" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#ea76cb" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#179299" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#bcc0cc" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#4c4f69" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#ea76cb" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#40a02b" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#df8e1d" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#40a02b" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="{accent}" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
## Name of theme

Catppuccin Latte Glass — a light theme based on the [Catppuccin Latte](https://github.com/catppuccin/catppuccin) palette (MIT), with a lavender → pink accent gradient, mauve cursor, and an **optional** pastel glow background image.

Per the contribution guidelines, no image is committed: the yaml includes a comment linking where to download it (original image generated for this theme, CC0).

## How Has This Been Tested?

Yes — ran `python3 ./scripts/gen_theme_previews.py standard` (preview SVG + README row included). Theme is in daily use in Warp on macOS.

![preview](https://raw.githubusercontent.com/rhlsthrm/themes/theme/catppuccin-latte-glass/standard/previews/catppuccin_latte_glass.yml.svg)