### PR TITLE
Add Paper Botanical light + dark themes

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -84,6 +84,7 @@
 |**[Outrun](outrun.yaml)**:|<img src='previews/outrun.yaml.svg' width='300'>|
 |**[Palenight](palenight.yaml)**:|<img src='previews/palenight.yaml.svg' width='300'>|
 |**[Panda Syntax](panda_syntax.yaml)**:|<img src='previews/panda_syntax.yaml.svg' width='300'>|
+|**[Paper Botanical](paper_botanical.yaml)**:|<img src='previews/paper_botanical.yaml.svg' width='300'>|
 |**[Papercolor Light](papercolor_light.yaml)**:|<img src='previews/papercolor_light.yaml.svg' width='300'>|
 |**[Pencil Dark](pencil_dark.yaml)**:|<img src='previews/pencil_dark.yaml.svg' width='300'>|
 |**[Pencil Light](pencil_light.yaml)**:|<img src='previews/pencil_light.yaml.svg' width='300'>|

--- a/standard/README.md
+++ b/standard/README.md
@@ -86,6 +86,7 @@
 |**[Palenight](palenight.yaml)**:|<img src='previews/palenight.yaml.svg' width='300'>|
 |**[Panda Syntax](panda_syntax.yaml)**:|<img src='previews/panda_syntax.yaml.svg' width='300'>|
 |**[Paper Botanical](paper_botanical.yaml)**:|<img src='previews/paper_botanical.yaml.svg' width='300'>|
+|**[Paper Botanical Dark](paper_botanical_dark.yaml)**:|<img src='previews/paper_botanical_dark.yaml.svg' width='300'>|
 |**[Papercolor Light](papercolor_light.yaml)**:|<img src='previews/papercolor_light.yaml.svg' width='300'>|
 |**[Pencil Dark](pencil_dark.yaml)**:|<img src='previews/pencil_dark.yaml.svg' width='300'>|
 |**[Pencil Light](pencil_light.yaml)**:|<img src='previews/pencil_light.yaml.svg' width='300'>|

--- a/standard/paper_botanical.yaml
+++ b/standard/paper_botanical.yaml
@@ -1,0 +1,25 @@
+name: Paper Botanical
+accent: '#2B5A38'
+cursor: '#2B5A38'
+background: '#FCFBF9'
+foreground: '#1A1A1A'
+details: lighter
+terminal_colors:
+  normal:
+    black: '#1A1A1A'
+    red: '#A33A3A'
+    green: '#2B5A38'
+    yellow: '#A85A20'
+    blue: '#4A7A8A'
+    magenta: '#4A3A6A'
+    cyan: '#3A7A6A'
+    white: '#C1BEB5'
+  bright:
+    black: '#8C8A80'
+    red: '#C36A6A'
+    green: '#6B9A78'
+    yellow: '#C88A50'
+    blue: '#7A9AAA'
+    magenta: '#8A7A9A'
+    cyan: '#6ABAAA'
+    white: '#EBEBE6'

--- a/standard/paper_botanical_dark.yaml
+++ b/standard/paper_botanical_dark.yaml
@@ -1,0 +1,25 @@
+name: Paper Botanical Dark
+accent: '#93C49E'
+cursor: '#93C49E'
+background: '#1B1A18'
+foreground: '#EDE9E1'
+details: darker
+terminal_colors:
+  normal:
+    black: '#33302B'
+    red: '#E6A0A0'
+    green: '#93C49E'
+    yellow: '#E4B27A'
+    blue: '#93BACD'
+    magenta: '#B9AAD6'
+    cyan: '#84C7B8'
+    white: '#CFC7B9'
+  bright:
+    black: '#BDB4A6'
+    red: '#F0B0B0'
+    green: '#AEDCB6'
+    yellow: '#F5CE96'
+    blue: '#AFD5E5'
+    magenta: '#D2C4EC'
+    cyan: '#A3E0D2'
+    white: '#F7F4ED'

--- a/standard/previews/paper_botanical.yaml.svg
+++ b/standard/previews/paper_botanical.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#FCFBF9" class="Dynamic" rx="5"/><text x="15" y="15" fill="#1A1A1A" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#4A7A8A" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#A33A3A" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#1A1A1A" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#1A1A1A" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#1A1A1A" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#1A1A1A" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1A1A1A" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#A33A3A" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#2B5A38" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#A85A20" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#4A7A8A" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#4A3A6A" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#3A7A6A" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#C1BEB5" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#1A1A1A" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#8C8A80" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#C36A6A" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#6B9A78" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#C88A50" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#7A9AAA" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#8A7A9A" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#6ABAAA" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#EBEBE6" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#1A1A1A" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#4A3A6A" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#2B5A38" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#A85A20" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#2B5A38" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#2B5A38" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/paper_botanical_dark.yaml.svg
+++ b/standard/previews/paper_botanical_dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#1B1A18" class="Dynamic" rx="5"/><text x="15" y="15" fill="#EDE9E1" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#93BACD" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#E6A0A0" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#EDE9E1" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#EDE9E1" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#EDE9E1" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#EDE9E1" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#33302B" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#E6A0A0" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#93C49E" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#E4B27A" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#93BACD" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#B9AAD6" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#84C7B8" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#CFC7B9" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#EDE9E1" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#BDB4A6" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#F0B0B0" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#AEDCB6" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#F5CE96" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#AFD5E5" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#D2C4EC" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#A3E0D2" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#F7F4ED" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#EDE9E1" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#B9AAD6" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#93C49E" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#E4B27A" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#93C49E" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#93C49E" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>


### PR DESCRIPTION
## Paper Botanical

A light/dark pair with warm paper tones and an earthy green accent — muted, desaturated colors for long sessions.

| | |
|---|---|
| **Paper Botanical** | <img src="https://raw.githubusercontent.com/chrismessina/themes/add-paper-botanical-theme/standard/previews/paper_botanical.yaml.svg" width="340"> |
| **Paper Botanical Dark** | <img src="https://raw.githubusercontent.com/chrismessina/themes/add-paper-botanical-theme/standard/previews/paper_botanical_dark.yaml.svg" width="340"> |

The dark variant keeps the light theme's hues (max drift 6.1°) and inverts lightness, so the two read as one family rather than two themes sharing a name.

### On the dark palette

It's brighter than a typical dark theme on purpose. Terminals render dimmed text — line numbers, comments, removed diff lines — by compositing it toward the background, so a color that measures fine at full opacity can be unreadable in the place it's actually used. An earlier revision of this theme passed a full-opacity contrast check and was still illegible in practice: `bright-black` measured 5.05:1 normally but 2.21:1 dimmed.

The shipped palette is tuned so every text color clears 3:1 *after* a 50% dim.

### Provenance

Ported from the "Paper" theme that ships with the [Otty](https://otty.sh) terminal — I'm not the original author of the light palette, so flagging that in case you'd like different attribution or would rather not take it. The dark variant is new work. Happy to adjust or close.

### Changes

- `standard/paper_botanical.yaml` + `standard/paper_botanical_dark.yaml`
- generated previews for both
- `standard/README.md` — two added table rows

Previews generated with `python3 ./scripts/gen_theme_previews.py standard`.

**Note on the README:** the script regenerates the whole table, which also adds the three `soft_tactile_warp_*` rows (merged in #140 but never regenerated), reorders the `zenburn*` rows, and strips the trailing newline. I reverted that and hand-inserted only my two rows to keep this diff scoped. #167 handles that housekeeping separately.
