### PR TITLE
Regenerate standard/README.md

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -104,6 +104,9 @@
 |**[Snazzy Green](snazzy_green.yaml)**:|<img src='previews/snazzy_green.yaml.svg' width='300'>|
 |**[Snazzy Red](snazzy_red.yaml)**:|<img src='previews/snazzy_red.yaml.svg' width='300'>|
 |**[Soft One Dark](soft_one_dark.yaml)**:|<img src='previews/soft_one_dark.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Cream](soft_tactile_warp_cream.yaml)**:|<img src='previews/soft_tactile_warp_cream.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Dark](soft_tactile_warp_dark.yaml)**:|<img src='previews/soft_tactile_warp_dark.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Light](soft_tactile_warp_light.yaml)**:|<img src='previews/soft_tactile_warp_light.yaml.svg' width='300'>|
 |**[Solarized Dark](solarized_dark.yaml)**:|<img src='previews/solarized_dark.yaml.svg' width='300'>|
 |**[Solarized Light](solarized_light.yaml)**:|<img src='previews/solarized_light.yaml.svg' width='300'>|
 |**[Spaceduck](spaceduck.yaml)**:|<img src='previews/spaceduck.yaml.svg' width='300'>|
@@ -128,6 +131,6 @@
 |**[Xterm](xterm.yaml)**:|<img src='previews/xterm.yaml.svg' width='300'>|
 |**[Zenbones Dark](zenbones_dark.yaml)**:|<img src='previews/zenbones_dark.yaml.svg' width='300'>|
 |**[Zenbones Light](zenbones_light.yaml)**:|<img src='previews/zenbones_light.yaml.svg' width='300'>|
-|**[Zenburn Colorblind High Contrast](zenburn_colorblind_high_contrast.yaml)**:|<img src='previews/zenburn_colorblind_high_contrast.yaml.svg' width='300'>|
-|**[Zenburn Colorblind](zenburn_colorblind.yaml)**:|<img src='previews/zenburn_colorblind.yaml.svg' width='300'>|
 |**[Zenburn](zenburn.yaml)**:|<img src='previews/zenburn.yaml.svg' width='300'>|
+|**[Zenburn Colorblind](zenburn_colorblind.yaml)**:|<img src='previews/zenburn_colorblind.yaml.svg' width='300'>|
+|**[Zenburn Colorblind High Contrast](zenburn_colorblind_high_contrast.yaml)**:|<img src='previews/zenburn_colorblind_high_contrast.yaml.svg' width='300'>|


### PR DESCRIPTION
Housekeeping only — no theme changes. This is the output of running the repo's own script with nothing else touched:

```
python3 ./scripts/gen_theme_previews.py standard
```

All 136 preview SVGs regenerate byte-identically, so the commit touches **only `standard/README.md`**.

### What changes

**1. Three missing rows.** The `soft_tactile_warp_{cream,dark,light}` themes were added in #140, but `README.md` was never regenerated afterward — the files exist in `standard/` and appear zero times in the current table. This adds them.

**2. `zenburn*` row order.** The script sorts by *filename*, where `_` (0x5F) sorts after `.` (0x2E), so `zenburn.yaml` comes first:

```
zenburn.yaml
zenburn_colorblind.yaml
zenburn_colorblind_high_contrast.yaml
```

The committed table has `zenburn` last, which is what you'd get sorting by *display name* instead. I've gone with the script's output since the README is generated, but if the current order is deliberate then the sort in `gen_theme_previews.py` is what wants fixing — happy to flip this either way.

**3. Trailing newline.** The script writes no final newline, so regenerating strips it. Called out in case that's unwanted; it's a one-line change to `main()` if so.

### Why it's separate

Split out from #166 (which adds a theme) so that PR stays scoped to three files and a reviewer doesn't have to adjudicate someone else's rows to approve it. The two don't conflict, and either can merge first — whichever lands second will need a trivial rebase on the table.