### PR TITLE
Add Vauxoo themes (Dark, Light, Vakyro)

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -105,6 +105,9 @@
 |**[Snazzy Green](snazzy_green.yaml)**:|<img src='previews/snazzy_green.yaml.svg' width='300'>|
 |**[Snazzy Red](snazzy_red.yaml)**:|<img src='previews/snazzy_red.yaml.svg' width='300'>|
 |**[Soft One Dark](soft_one_dark.yaml)**:|<img src='previews/soft_one_dark.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Cream](soft_tactile_warp_cream.yaml)**:|<img src='previews/soft_tactile_warp_cream.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Dark](soft_tactile_warp_dark.yaml)**:|<img src='previews/soft_tactile_warp_dark.yaml.svg' width='300'>|
+|**[Soft Tactile Warp Light](soft_tactile_warp_light.yaml)**:|<img src='previews/soft_tactile_warp_light.yaml.svg' width='300'>|
 |**[Solarized Dark](solarized_dark.yaml)**:|<img src='previews/solarized_dark.yaml.svg' width='300'>|
 |**[Solarized Light](solarized_light.yaml)**:|<img src='previews/solarized_light.yaml.svg' width='300'>|
 |**[Spaceduck](spaceduck.yaml)**:|<img src='previews/spaceduck.yaml.svg' width='300'>|
@@ -118,6 +121,9 @@
 |**[Tokyo Night Storm](tokyo_night_storm.yaml)**:|<img src='previews/tokyo_night_storm.yaml.svg' width='300'>|
 |**[Tomorrow Night](tomorrow_night.yaml)**:|<img src='previews/tomorrow_night.yaml.svg' width='300'>|
 |**[Tomorrow Night Bright](tomorrow_night_bright.yaml)**:|<img src='previews/tomorrow_night_bright.yaml.svg' width='300'>|
+|**[Vauxoo Dark](vauxoo_dark.yaml)**:|<img src='previews/vauxoo_dark.yaml.svg' width='300'>|
+|**[Vauxoo Light](vauxoo_light.yaml)**:|<img src='previews/vauxoo_light.yaml.svg' width='300'>|
+|**[Vauxoo Vakyro](vauxoo_vakyro.yaml)**:|<img src='previews/vauxoo_vakyro.yaml.svg' width='300'>|
 |**[Vitesse Black](vitesse_black.yaml)**:|<img src='previews/vitesse_black.yaml.svg' width='300'>|
 |**[Vitesse Dark](vitesse_dark.yaml)**:|<img src='previews/vitesse_dark.yaml.svg' width='300'>|
 |**[Vitesse Dark Soft](vitesse_dark_soft.yaml)**:|<img src='previews/vitesse_dark_soft.yaml.svg' width='300'>|
@@ -129,6 +135,6 @@
 |**[Xterm](xterm.yaml)**:|<img src='previews/xterm.yaml.svg' width='300'>|
 |**[Zenbones Dark](zenbones_dark.yaml)**:|<img src='previews/zenbones_dark.yaml.svg' width='300'>|
 |**[Zenbones Light](zenbones_light.yaml)**:|<img src='previews/zenbones_light.yaml.svg' width='300'>|
-|**[Zenburn Colorblind High Contrast](zenburn_colorblind_high_contrast.yaml)**:|<img src='previews/zenburn_colorblind_high_contrast.yaml.svg' width='300'>|
-|**[Zenburn Colorblind](zenburn_colorblind.yaml)**:|<img src='previews/zenburn_colorblind.yaml.svg' width='300'>|
 |**[Zenburn](zenburn.yaml)**:|<img src='previews/zenburn.yaml.svg' width='300'>|
+|**[Zenburn Colorblind](zenburn_colorblind.yaml)**:|<img src='previews/zenburn_colorblind.yaml.svg' width='300'>|
+|**[Zenburn Colorblind High Contrast](zenburn_colorblind_high_contrast.yaml)**:|<img src='previews/zenburn_colorblind_high_contrast.yaml.svg' width='300'>|

--- a/standard/previews/vauxoo_dark.yaml.svg
+++ b/standard/previews/vauxoo_dark.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#282C2F" class="Dynamic" rx="5"/><text x="15" y="15" fill="#D6DAE0" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#5498CC" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#E11E4D" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#D6DAE0" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#D6DAE0" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#D6DAE0" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#D6DAE0" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#282C2F" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#E11E4D" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#3AA55D" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#E4A900" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#5498CC" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#9B7BC8" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#82BCCE" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#D6DAE0" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#D6DAE0" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#6E7379" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#F0537A" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#5BC57F" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#E9BE44" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#82BCCE" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#B79BDB" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#A5D3E0" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#FFFFFF" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#D6DAE0" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#9B7BC8" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#3AA55D" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#E4A900" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#3AA55D" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#AC0340" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/vauxoo_light.yaml.svg
+++ b/standard/previews/vauxoo_light.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#FFFFFF" class="Dynamic" rx="5"/><text x="15" y="15" fill="#282C2F" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#2E6E9E" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#AC0340" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#282C2F" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#282C2F" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#282C2F" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#282C2F" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#282C2F" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#AC0340" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#2E7D46" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#B77800" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#2E6E9E" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#67498E" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#3D7A99" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#D6DAE0" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#282C2F" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#6E7379" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#E11E4D" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#3AA55D" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#E4A900" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#5498CC" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#9B7BC8" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#82BCCE" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#282C2F" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#282C2F" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#67498E" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#2E7D46" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#B77800" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#2E7D46" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#AC0340" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/previews/vauxoo_vakyro.yaml.svg
+++ b/standard/previews/vauxoo_vakyro.yaml.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 145"><rect width="300" height="145" fill="#201D24" class="Dynamic" rx="5"/><text x="15" y="15" fill="#E8E3EE" class="Dynamic" font-family="monospace" font-size=".6em">ls</text><text x="15" y="30" fill="#9B7BC8" class="Dynamic" font-family="monospace" font-size=".6em">
+dir
+</text><text x="65" y="30" fill="#E15A7C" class="Dynamic" font-family="monospace" font-size=".6em">
+executable
+</text><text x="175" y="30" fill="#E8E3EE" class="Dynamic" font-family="monospace" font-size=".6em">
+file
+</text><path stroke="#E8E3EE" d="M0 40h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="55" fill="#E8E3EE" class="Dynamic" font-family="monospace" font-size=".6em">bash ~/colors.sh</text><text x="15" y="70" fill="#E8E3EE" class="Dynamic" font-family="monospace" font-size=".6em">
+normal:
+</text><text x="55" y="70" fill="#1C1B19" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="70" fill="#E15A7C" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="70" fill="#3AA55D" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="70" fill="#E9BE44" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="70" fill="#9B7BC8" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="70" fill="#F3C5D9" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="70" fill="#82BCCE" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="70" fill="#E8E3EE" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><text x="15" y="85" fill="#E8E3EE" class="Dynamic" font-family="monospace" font-size=".6em">
+bright:
+</text><text x="55" y="85" fill="#7C7385" class="Dynamic" font-family="monospace" font-size=".6em">
+black
+</text><text x="85" y="85" fill="#F0537A" class="Dynamic" font-family="monospace" font-size=".6em">
+red
+</text><text x="105" y="85" fill="#5BC57F" class="Dynamic" font-family="monospace" font-size=".6em">
+green
+</text><text x="135" y="85" fill="#F2D06B" class="Dynamic" font-family="monospace" font-size=".6em">
+yellow
+</text><text x="170" y="85" fill="#B79BDB" class="Dynamic" font-family="monospace" font-size=".6em">
+blue
+</text><text x="195" y="85" fill="#F8D9E6" class="Dynamic" font-family="monospace" font-size=".6em">
+magenta
+</text><text x="235" y="85" fill="#A5D3E0" class="Dynamic" font-family="monospace" font-size=".6em">
+cyan
+</text><text x="260" y="85" fill="#FFFFFF" class="Dynamic" font-family="monospace" font-size=".6em">
+white
+</text><path stroke="#E8E3EE" d="M0 95h300" class="Dynamic" style="stroke-width:.2"/><text x="15" y="110" fill="#F3C5D9" class="Dynamic" font-family="monospace" font-size=".6em">
+~/project
+</text><text x="65" y="110" fill="#3AA55D" class="Dynamic" font-family="monospace" font-size=".6em">
+git(
+    </text><text x="85" y="110" fill="#E9BE44" class="Dynamic" font-family="monospace" font-size=".6em">
+      main
+    </text><text x="113" y="110" fill="#3AA55D" class="Dynamic" font-family="monospace" font-size=".6em">
+      )
+</text><path stroke="#7A5FA0" d="M15 120v10" class="Dynamic" style="stroke-width:2"/></svg>

--- a/standard/vauxoo_dark.yaml
+++ b/standard/vauxoo_dark.yaml
@@ -1,0 +1,25 @@
+# Vauxoo Dark — Vauxoo brand palette (https://www.vauxoo.com/assets)
+name: 'Vauxoo Dark'
+accent: '#AC0340'
+background: '#282C2F'
+foreground: '#D6DAE0'
+details: darker
+terminal_colors:
+  normal:
+    black: '#282C2F'
+    red: '#E11E4D'
+    green: '#3AA55D'
+    yellow: '#E4A900'
+    blue: '#5498CC'
+    magenta: '#9B7BC8'
+    cyan: '#82BCCE'
+    white: '#D6DAE0'
+  bright:
+    black: '#6E7379'
+    red: '#F0537A'
+    green: '#5BC57F'
+    yellow: '#E9BE44'
+    blue: '#82BCCE'
+    magenta: '#B79BDB'
+    cyan: '#A5D3E0'
+    white: '#FFFFFF'

--- a/standard/vauxoo_light.yaml
+++ b/standard/vauxoo_light.yaml
@@ -1,0 +1,25 @@
+# Vauxoo Light — Vauxoo brand palette (https://www.vauxoo.com/assets)
+name: 'Vauxoo Light'
+accent: '#AC0340'
+background: '#FFFFFF'
+foreground: '#282C2F'
+details: lighter
+terminal_colors:
+  normal:
+    black: '#282C2F'
+    red: '#AC0340'
+    green: '#2E7D46'
+    yellow: '#B77800'
+    blue: '#2E6E9E'
+    magenta: '#67498E'
+    cyan: '#3D7A99'
+    white: '#D6DAE0'
+  bright:
+    black: '#6E7379'
+    red: '#E11E4D'
+    green: '#3AA55D'
+    yellow: '#E4A900'
+    blue: '#5498CC'
+    magenta: '#9B7BC8'
+    cyan: '#82BCCE'
+    white: '#282C2F'

--- a/standard/vauxoo_vakyro.yaml
+++ b/standard/vauxoo_vakyro.yaml
@@ -1,0 +1,25 @@
+# Vauxoo Vakyro — Vauxoo brand palette (https://www.vauxoo.com/assets)
+name: 'Vauxoo Vakyro'
+accent: '#7A5FA0'
+background: '#201D24'
+foreground: '#E8E3EE'
+details: darker
+terminal_colors:
+  normal:
+    black: '#1C1B19'
+    red: '#E15A7C'
+    green: '#3AA55D'
+    yellow: '#E9BE44'
+    blue: '#9B7BC8'
+    magenta: '#F3C5D9'
+    cyan: '#82BCCE'
+    white: '#E8E3EE'
+  bright:
+    black: '#7C7385'
+    red: '#F0537A'
+    green: '#5BC57F'
+    yellow: '#F2D06B'
+    blue: '#B79BDB'
+    magenta: '#F8D9E6'
+    cyan: '#A5D3E0'
+    white: '#FFFFFF'


### PR DESCRIPTION
Adds three themes based on the official [Vauxoo brand palette](https://www.vauxoo.com/assets) (ERP consulting company, https://www.vauxoo.com):

- **Vauxoo Dark** — blue-gray base `#282C2F`, Vauxoo red `#AC0340` accent, gold cursor.
- **Vauxoo Light** — white and smoke-gray surfaces with the same red identity.
- **Vauxoo Vakyro** — warm black with the purples `#6F5198` and pink `#F3C5D9` of Vakyro, the company mascot.

They match the [Vauxoo Theme for VSCode](https://marketplace.visualstudio.com/items?itemName=vauxoo.vauxoo-theme) ([source](https://github.com/Vauxoo/vauxoo-theme)) so the terminal and editor share one palette. Previews generated with `scripts/gen_theme_previews.py standard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)